### PR TITLE
[Feat] 지역 조회 API 구현

### DIFF
--- a/controllers/region/regionController.js
+++ b/controllers/region/regionController.js
@@ -1,0 +1,31 @@
+import {
+  findAllSidos,
+  findSigunguBySidoCode,
+} from "../../model/region/regionModel.js";
+import { success, fail } from "../../utils/response.js";
+
+export const getSidoList = async (req, res) => {
+  try {
+    const sidoList = await findAllSidos();
+    return success(res, sidoList, "시/도 목록 조회 성공");
+  } catch (error) {
+    console.error("시/도 목록 조회 실패:", error);
+    return fail(res, "시/도 목록 조회 중 서버 오류가 발생했습니다.");
+  }
+};
+
+export const getSigunguList = async (req, res) => {
+  try {
+    const { sidoCode } = req.query;
+
+    if (!sidoCode || String(sidoCode).trim() === "") {
+      return fail(res, "sidoCode는 필수 요청값입니다.", 400);
+    }
+
+    const sigunguList = await findSigunguBySidoCode(String(sidoCode).trim());
+    return success(res, sigunguList, "시/군/구 목록 조회 성공");
+  } catch (error) {
+    console.error("시/군/구 목록 조회 실패:", error);
+    return fail(res, "시/군/구 목록 조회 중 서버 오류가 발생했습니다.");
+  }
+};

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ import express from "express";
 
 import userRoutes from "./routes/user/userRoutes.js";
 import authRoutes from "./routes/auth/authRoutes.js";
+import regionRoutes from "./routes/region/regionRoutes.js";
 
 import errorHandler from "./middleware/errorHandler.js";
 
@@ -12,6 +13,7 @@ app.use(express.json());
 // 라우터
 app.use("/api/users", userRoutes);
 app.use("/api/auth", authRoutes);
+app.use("/api/regions", regionRoutes);
 
 // 에러 핸들러 (항상 마지막!)
 app.use(errorHandler);

--- a/model/region/regionModel.js
+++ b/model/region/regionModel.js
@@ -1,0 +1,34 @@
+import pool from "../../config/db.js";
+
+export const findAllSidos = async () => {
+  const sql = `
+    SELECT 
+      region_code AS regionCode,
+      name,
+      level,
+      parent_code AS parentCode
+    FROM region
+    WHERE level = 1
+    ORDER BY region_code ASC
+  `;
+
+  const [rows] = await pool.query(sql);
+  return rows;
+};
+
+export const findSigunguBySidoCode = async (sidoCode) => {
+  const sql = `
+    SELECT 
+      region_code AS regionCode,
+      name,
+      level,
+      parent_code AS parentCode
+    FROM region
+    WHERE level = 2
+      AND parent_code = ?
+    ORDER BY region_code ASC
+  `;
+
+  const [rows] = await pool.query(sql, [sidoCode]);
+  return rows;
+};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "morgan": "^1.10.1",
     "mysql2": "^3.20.0",
     "nodemailer": "^8.0.4",
-    "nodemon": "^3.1.14",
     "resend": "^6.10.0"
   },
   "devDependencies": {

--- a/routes/region/regionRoutes.js
+++ b/routes/region/regionRoutes.js
@@ -1,0 +1,12 @@
+import express from "express";
+import {
+  getSidoList,
+  getSigunguList,
+} from "../../controllers/region/regionController.js";
+
+const router = express.Router();
+
+router.get("/sidos", getSidoList);
+router.get("/sigungu", getSigunguList);
+
+export default router;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 시도 조회 API를 추가했습니다.
- 시군구 조회 API를 추가했습니다.
- region 테이블의 level, parent_code를 기준으로 지역 조회 로직을 구현했습니다.
- nodemon 중복 의존성 제거

### 테스트 결과
- 시도 목록 조회 성공 확인
- 시군구 목록 조회 성공 확인
- sidoCode 없이 시군구 조회 요청 시 에러 응답 확인

### 관련 이슈
- Closes #4 