### PR TITLE
[Fix] API 권한 조정 및 DB 테이블명 동기화

### DIFF
--- a/model/user/userModel.js
+++ b/model/user/userModel.js
@@ -2,14 +2,14 @@ import conn from "../../config/db.js";
 
 // 사용자 조회
 export const findByEmail = async (email) => {
-  const sql = "SELECT * FROM user WHERE email = ?";
+  const sql = "SELECT * FROM users WHERE email = ?";
   const [rows] = await conn.execute(sql, [email]);
 
   return rows[0];
 };
 
 export const findById = async (id) => {
-  const sql = "SELECT * FROM user WHERE id = ?";
+  const sql = "SELECT * FROM users WHERE id = ?";
   const [rows] = await conn.execute(sql, [id]);
 
   return rows[0];
@@ -24,7 +24,7 @@ export const createUser = async ({
   region_code,
 }) => {
   const sql = `
-    INSERT INTO user (
+    INSERT INTO users (
       username,
       nickname, 
       email, 

--- a/routes/region/regionRoutes.js
+++ b/routes/region/regionRoutes.js
@@ -3,11 +3,10 @@ import {
   getSidoList,
   getSigunguList,
 } from "../../controllers/region/regionController.js";
-import { authMiddleware } from "../../middleware/authMiddleware.js";
 
 const router = express.Router();
 
-router.get("/sidos", authMiddleware, getSidoList);
-router.get("/sigungu", authMiddleware, getSigunguList);
+router.get("/sidos", getSidoList);
+router.get("/sigungu", getSigunguList);
 
 export default router;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
지역 정보 조회 API 접근 권한 변경
- 비로그인 사용자도 메인 페이지에서 정보를 확인할 수 있도록 sidos, sigungu 라우트의 인증 미들웨어를 제거했습니다.

DB 테이블 참조 명칭 수정
- 데이터베이스 스키마 변경 사항에 맞춰 userModel 내 테이블명을 user에서 users로 업데이트했습니다.

### 테스트 결과
비로그인(토큰 없음) 상태에서 /api/regions/sidos 호출 시 정상 응답 확인
테이블명 변경(users) 후에도 로그인 API가 정상적으로 작동하는 것을 확인했습니다.

### 관련 이슈
- Closes #17          