### PR TITLE
[Feat] 인증서 검토 정책 및 관리자 조회 기능 추가

### DIFF
--- a/controllers/certificate/certificateController.js
+++ b/controllers/certificate/certificateController.js
@@ -1,8 +1,9 @@
 import {
-  uploadCertificateService,
-  getMyCertificatesService,
-  getCertificatesByParticipationService,
-  reviewCertificateService,
+  uploadCertificate as uploadCertificateService,
+  getMyCertificates as getMyCertificatesService,
+  getCertificatesByParticipation as getCertificatesByParticipationService,
+  getPendingCertificates as getPendingCertificatesService,
+  reviewCertificate as reviewCertificateService,
 } from "../../services/certificate/certificateService.js";
 import { success } from "../../utils/response.js";
 import asyncHandler from "../../middleware/asyncHandler.js";
@@ -28,6 +29,13 @@ export const getMyCertificates = asyncHandler(async (req, res) => {
   const data = await getMyCertificatesService(userId);
 
   return success(res, data, "내 인증서 목록 조회 성공", 200);
+});
+
+// 관리자용 대기 중 인증서 목록 조회
+export const getPendingCertificates = asyncHandler(async (req, res) => {
+  const data = await getPendingCertificatesService();
+
+  return success(res, data, "대기 중 인증서 목록 조회 성공", 200);
 });
 
 // 봉사활동별 제출한 인증서 목록 조회

--- a/model/certificate/certificateModel.js
+++ b/model/certificate/certificateModel.js
@@ -29,8 +29,55 @@ export const findLastSubmissionNo = async (participationId) => {
   return rows[0]?.lastSubmissionNo ?? 0;
 };
 
+// 최신 인증서 제출 내역 조회
+export const findLatestCertificateByParticipationId = async (
+  participationId,
+) => {
+  const sql = `
+    SELECT
+      id,
+      volunteer_participation_id,
+      file_url,
+      file_hash,
+      status,
+      submission_no,
+      submitted_at,
+      reviewed_at,
+      reviewer_id,
+      rejected_reason
+    FROM certificate_submission
+    WHERE volunteer_participation_id = ?
+    ORDER BY submission_no DESC
+    LIMIT 1
+  `;
+
+  const [rows] = await pool.query(sql, [participationId]);
+  return rows[0];
+};
+
+// 동일 참여 이력에 동일 파일 해시가 이미 있는지 조회
+export const findCertificateByParticipationIdAndFileHash = async ({
+  participationId,
+  fileHash,
+}) => {
+  const sql = `
+    SELECT
+      id,
+      volunteer_participation_id,
+      file_hash,
+      submission_no,
+      status
+    FROM certificate_submission
+    WHERE volunteer_participation_id = ?
+      AND file_hash = ?
+    LIMIT 1
+  `;
+
+  const [rows] = await pool.query(sql, [participationId, fileHash]);
+  return rows[0];
+};
+
 // 인증서 제출 기록 생성
-// 불필요한 외곽 괄호를 제거하고 async 화살표 함수로 정의
 export const createCertificateSubmission = async ({
   participationId,
   fileUrl,
@@ -49,7 +96,6 @@ export const createCertificateSubmission = async ({
     VALUES (?, ?, ?, 'PENDING', ?, NOW())
   `;
 
-  // 이제 await가 정상적으로 async 함수 내부에서 작동합니다.
   const [result] = await pool.query(sql, [
     participationId,
     fileUrl,
@@ -107,6 +153,38 @@ export const findCertificatesByParticipationId = async (participationId) => {
     ORDER BY submission_no DESC
   `;
   const [rows] = await pool.query(sql, [participationId]);
+  return rows;
+};
+
+// 관리자용 대기 중 인증서 목록 조회
+export const findPendingCertificates = async () => {
+  const sql = `
+    SELECT
+      cs.id,
+      cs.volunteer_participation_id,
+      cs.file_url,
+      cs.file_hash,
+      cs.status,
+      cs.submission_no,
+      cs.submitted_at,
+      vp.user_id,
+      vp.activity_title,
+      vp.organization_name,
+      vp.start_date,
+      vp.end_date,
+      vp.requested_volunteer_hour,
+      u.nickname,
+      u.email
+    FROM certificate_submission cs
+    INNER JOIN volunteer_participation vp
+      ON cs.volunteer_participation_id = vp.id
+    INNER JOIN users u
+      ON vp.user_id = u.id
+    WHERE cs.status = 'PENDING'
+    ORDER BY cs.submitted_at ASC, cs.submission_no ASC
+  `;
+
+  const [rows] = await pool.query(sql);
   return rows;
 };
 

--- a/routes/certificate/certificateRoutes.js
+++ b/routes/certificate/certificateRoutes.js
@@ -3,6 +3,7 @@ import {
   uploadCertificate,
   getMyCertificates,
   getCertificatesByParticipation,
+  getPendingCertificates,
   reviewCertificate,
 } from "../../controllers/certificate/certificateController.js";
 import { certificateUpload } from "../../middleware/upload.js";
@@ -19,6 +20,7 @@ router.post(
 );
 
 router.get("/my", authMiddleware, getMyCertificates);
+router.get("/admin/pending", authMiddleware, isAdmin, getPendingCertificates);
 router.get("/:participationId", authMiddleware, getCertificatesByParticipation);
 router.patch(
   "/:certificateId/review",

--- a/services/certificate/certificateService.js
+++ b/services/certificate/certificateService.js
@@ -1,20 +1,19 @@
 import {
   findParticipationById,
   findLastSubmissionNo,
+  findLatestCertificateByParticipationId,
+  findCertificateByParticipationIdAndFileHash,
   createCertificateSubmission,
   findCertificatesByUserId,
   findCertificatesByParticipationId,
   findCertificateById,
-  reviewCertificate,
+  findPendingCertificates,
+  reviewCertificate as reviewCertificateModel,
 } from "../../model/certificate/certificateModel.js";
 import { generateFileHash } from "../../utils/fileHash.js";
 
-// 인증서 업로드 서비스
-export const uploadCertificateService = async ({
-  participationId,
-  userId,
-  file,
-}) => {
+// 인증서 업로드
+export const uploadCertificate = async ({ participationId, userId, file }) => {
   if (!file) {
     const error = new Error("업로드할 인증서가 없습니다.");
     error.status = 400;
@@ -37,10 +36,45 @@ export const uploadCertificateService = async ({
     throw error;
   }
 
-  const lastSubmissionNo = await findLastSubmissionNo(participationId);
-  const nextSubmissionNo = lastSubmissionNo + 1;
+  const latestCertificate =
+    await findLatestCertificateByParticipationId(participationId);
+
+  if (latestCertificate?.status === "PENDING") {
+    const error = new Error(
+      "현재 검토 중인 인증서가 있어 재제출할 수 없습니다.",
+    );
+    error.status = 409;
+    throw error;
+  }
+
+  if (latestCertificate?.status === "APPROVED") {
+    const error = new Error(
+      "이미 승인된 인증서가 있어 다시 제출할 수 없습니다.",
+    );
+    error.status = 409;
+    throw error;
+  }
+
   const fileHash = await generateFileHash(file.path);
 
+  if (latestCertificate?.status === "REJECTED") {
+    const duplicatedCertificate =
+      await findCertificateByParticipationIdAndFileHash({
+        participationId,
+        fileHash,
+      });
+
+    if (duplicatedCertificate) {
+      const error = new Error(
+        "이전에 제출한 인증서와 동일한 파일은 재제출할 수 없습니다.",
+      );
+      error.status = 409;
+      throw error;
+    }
+  }
+
+  const lastSubmissionNo = await findLastSubmissionNo(participationId);
+  const nextSubmissionNo = lastSubmissionNo + 1;
   const fileUrl = `/uploads/certificates/${file.filename}`;
 
   const certificateId = await createCertificateSubmission({
@@ -61,12 +95,17 @@ export const uploadCertificateService = async ({
 };
 
 // 내 인증서 목록 조회 서비스
-export const getMyCertificatesService = async (userId) => {
+export const getMyCertificates = async (userId) => {
   return await findCertificatesByUserId(userId);
 };
 
+// 관리자용 대기 중 인증서 목록 조회
+export const getPendingCertificates = async () => {
+  return await findPendingCertificates();
+};
+
 // 참여 이력별 인증서 목록 조회 서비스
-export const getCertificatesByParticipationService = async (
+export const getCertificatesByParticipation = async (
   participationId,
   userId,
 ) => {
@@ -88,7 +127,7 @@ export const getCertificatesByParticipationService = async (
 };
 
 // 관리자 인증서 검토 서비스 (승인/반려)
-export const reviewCertificateService = async ({
+export const reviewCertificate = async ({
   certificateId,
   reviewerId,
   status,
@@ -99,6 +138,12 @@ export const reviewCertificateService = async ({
   if (!certificate) {
     const error = new Error("인증서 제출 내역을 찾을 수 없습니다.");
     error.status = 404;
+    throw error;
+  }
+
+  if (certificate.status !== "PENDING") {
+    const error = new Error("검토 대기 상태의 인증서만 처리할 수 있습니다.");
+    error.status = 409;
     throw error;
   }
 
@@ -114,7 +159,7 @@ export const reviewCertificateService = async ({
     throw error;
   }
 
-  await reviewCertificate({
+  await reviewCertificateModel({
     certificateId,
     status,
     reviewerId,


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 관리자용 대기 중 인증서 목록 조회 API를 추가했습니다.
- 인증서 업로드 시 최신 제출 상태가 PENDING 또는 APPROVED인 경우 재제출이 불가능하도록 제한했습니다.
- 최신 제출 상태가 REJECTED인 경우에만 재제출할 수 있도록 처리했습니다.
- 반려 후 재제출 시 동일한 파일 해시의 인증서는 다시 업로드할 수 없도록 검증을 추가했습니다.
- 인증서 검토 시 PENDING 상태의 인증서만 승인 또는 반려할 수 있도록 검증을 추가했습니다.
- 인증서 최신 제출 내역 조회 및 동일 파일 해시 조회를 위한 모델 로직을 추가했습니다.

### 테스트 결과
- 관리자 계정으로 대기 중인 인증서 목록 조회 성공 확인
- 최신 인증서 상태가 PENDING인 경우 재제출 차단 확인
- 최신 인증서 상태가 APPROVED인 경우 재제출 차단 확인
- 최신 인증서 상태가 REJECTED인 경우 다른 파일로 재제출 성공 확인
- 반려된 이력에 동일한 파일 재제출 시 차단 확인
- PENDING 상태가 아닌 인증서 검토 요청 시 차단 확인
- PENDING 상태의 인증서 승인 및 반려 처리 성공 확인

### 관련 이슈
- Closes #23              