### PR TITLE
[Feat] 봉사활동 지역 문자열 기반 지역 코드 매핑 기능 구현

### DIFF
--- a/controllers/region/regionController.js
+++ b/controllers/region/regionController.js
@@ -1,6 +1,6 @@
 import {
   findAllSidos,
-  findSigunguBySidoCode,
+  findChildRegionsByParentCode,
 } from "../../model/region/regionModel.js";
 import { success, fail } from "../../utils/response.js";
 
@@ -22,7 +22,9 @@ export const getSigunguList = async (req, res) => {
       return fail(res, "sidoCode는 필수 요청값입니다.", 400);
     }
 
-    const sigunguList = await findSigunguBySidoCode(String(sidoCode).trim());
+    const sigunguList = await findChildRegionsByParentCode(
+      String(sidoCode).trim(),
+    );
     return success(res, sigunguList, "시/군/구 목록 조회 성공");
   } catch (error) {
     console.error("시/군/구 목록 조회 실패:", error);

--- a/model/region/regionModel.js
+++ b/model/region/regionModel.js
@@ -16,7 +16,7 @@ export const findAllSidos = async () => {
   return rows;
 };
 
-export const findSigunguBySidoCode = async (sidoCode) => {
+export const findChildRegionsByParentCode = async (parentCode) => {
   const sql = `
     SELECT 
       region_code AS regionCode,
@@ -24,11 +24,50 @@ export const findSigunguBySidoCode = async (sidoCode) => {
       level,
       parent_code AS parentCode
     FROM region
-    WHERE level = 2
-      AND parent_code = ?
+    WHERE parent_code = ?
     ORDER BY region_code ASC
   `;
 
-  const [rows] = await pool.query(sql, [sidoCode]);
+  const [rows] = await pool.query(sql, [parentCode]);
   return rows;
+};
+
+export const findRegionByNameAndLevel = async ({ name, level }) => {
+  const sql = `
+    SELECT
+      region_code,
+      name,
+      level,
+      parent_code
+    FROM region
+    WHERE name = ? AND level = ?
+    LIMIT 1
+  `;
+
+  const [rows] = await pool.query(sql, [name, level]);
+  return rows[0] || null;
+};
+
+export const findChildRegionByNameAndParentCode = async ({
+  name,
+  parentCode,
+}) => {
+  const sql = `
+    SELECT
+      region_code,
+      name,
+      level,
+      parent_code
+    FROM region
+    WHERE name = ?
+      AND parent_code = ?
+    LIMIT 1
+  `;
+
+  const [rows] = await pool.query(sql, [name, parentCode]);
+  return rows[0] || null;
+};
+
+export const findSidoByName = async (name) => {
+  return findRegionByNameAndLevel({ name, level: 1 });
 };

--- a/services/region/regionService.js
+++ b/services/region/regionService.js
@@ -1,0 +1,88 @@
+import {
+  findSidoByName,
+  findChildRegionByNameAndParentCode,
+} from "../../model/region/regionModel.js";
+import {
+  normalizeLocationText,
+  normalizeSidoName,
+  splitLocationTokens,
+  buildChildRegionCandidates,
+} from "../../utils/regionLocationParser.js";
+
+const buildResolveResult = ({ region = null, sourceText = "" }) => {
+  return {
+    regionCode: region?.region_code || null,
+    region,
+    sourceText,
+  };
+};
+
+const findMatchedChildRegion = async ({ candidates, parentCode }) => {
+  for (const candidate of candidates) {
+    const region = await findChildRegionByNameAndParentCode({
+      name: candidate,
+      parentCode,
+    });
+
+    if (region) {
+      return region;
+    }
+  }
+
+  return null;
+};
+
+export const resolveRegionFromLocationText = async (locationText) => {
+  const sourceText = normalizeLocationText(locationText);
+  const tokens = splitLocationTokens(locationText);
+
+  if (tokens.length === 0) {
+    return buildResolveResult({ region: null, sourceText: "" });
+  }
+
+  const firstToken = normalizeSidoName(tokens[0]);
+  const secondToken = tokens[1] || null;
+  const thirdToken = tokens[2] || null;
+
+  // 1) 첫 토큰은 시/도
+  const sido = await findSidoByName(firstToken);
+
+  if (!sido) {
+    return buildResolveResult({ region: null, sourceText });
+  }
+
+  // 2) 시/도만 있으면 시/도 반환
+  if (!secondToken) {
+    return buildResolveResult({ region: sido, sourceText });
+  }
+
+  // 3) 둘째 토큰은 시/도의 직속 자식
+  const secondCandidates = buildChildRegionCandidates(secondToken);
+
+  const childRegion = await findMatchedChildRegion({
+    candidates: secondCandidates,
+    parentCode: sido.region_code,
+  });
+
+  if (!childRegion) {
+    return buildResolveResult({ region: sido, sourceText });
+  }
+
+  // 4) 셋째 토큰이 없으면 둘째 토큰 매칭 결과 반환
+  if (!thirdToken) {
+    return buildResolveResult({ region: childRegion, sourceText });
+  }
+
+  // 5) 셋째 토큰은 둘째 토큰의 직속 자식
+  const thirdCandidates = buildChildRegionCandidates(thirdToken);
+
+  const grandChildRegion = await findMatchedChildRegion({
+    candidates: thirdCandidates,
+    parentCode: childRegion.region_code,
+  });
+
+  return buildResolveResult({
+    region: grandChildRegion || childRegion,
+    sourceText,
+  });
+};

--- a/utils/regionLocationParser.js
+++ b/utils/regionLocationParser.js
@@ -1,0 +1,77 @@
+const normalizeWhitespace = (text = "") => {
+  return text.replace(/\s+/g, " ").trim();
+};
+
+const removeBracketText = (text = "") => {
+  return text.replace(/\([^)]*\)/g, " ").trim();
+};
+
+const normalizeDelimiter = (text = "") => {
+  return text.replace(/[,/>\-]+/g, " ");
+};
+
+export const normalizeLocationText = (text = "") => {
+  return normalizeWhitespace(normalizeDelimiter(removeBracketText(text)));
+};
+
+const sidoAliasMap = {
+  서울: "서울특별시",
+  서울시: "서울특별시",
+  부산: "부산광역시",
+  부산시: "부산광역시",
+  대구: "대구광역시",
+  대구시: "대구광역시",
+  인천: "인천광역시",
+  인천시: "인천광역시",
+  광주: "광주광역시",
+  광주시: "광주광역시",
+  대전: "대전광역시",
+  대전시: "대전광역시",
+  울산: "울산광역시",
+  울산시: "울산광역시",
+  세종: "세종특별자치시",
+  세종시: "세종특별자치시",
+  경기: "경기도",
+  강원: "강원특별자치도",
+  강원도: "강원특별자치도",
+  충북: "충청북도",
+  충남: "충청남도",
+  전북: "전북특별자치도",
+  전라북도: "전북특별자치도",
+  전남: "전라남도",
+  경북: "경상북도",
+  경남: "경상남도",
+  제주: "제주특별자치도",
+  제주도: "제주특별자치도",
+};
+
+export const normalizeSidoName = (token = "") => {
+  const trimmed = token.trim();
+  return sidoAliasMap[trimmed] || trimmed;
+};
+
+export const splitLocationTokens = (text = "") => {
+  return normalizeLocationText(text).split(" ").filter(Boolean);
+};
+
+const unique = (values = []) => {
+  return [...new Set(values.filter(Boolean))];
+};
+
+export const buildChildRegionCandidates = (name = "") => {
+  const trimmed = name.trim();
+
+  if (!trimmed) {
+    return [];
+  }
+
+  if (
+    trimmed.endsWith("시") ||
+    trimmed.endsWith("군") ||
+    trimmed.endsWith("구")
+  ) {
+    return [trimmed];
+  }
+
+  return unique([trimmed, `${trimmed}시`, `${trimmed}군`, `${trimmed}구`]);
+};


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 봉사활동 지역 문자열을 기준으로 지역 코드를 매핑하는 기능을 추가했습니다.
- 지역명 공백 및 괄호 제거, 시도 별칭 정규화 로직을 구현했습니다.
- 부모-자식 관계를 기준으로 지역을 탐색하도록 지역 매핑 로직을 수정했습니다.
- 시도 직속 하위 지역 및 하위 구역까지 매핑할 수 있도록 지역 후보 생성 로직을 구현했습니다.

### 테스트 결과
- 서울 종로 입력 시 종로구로 매핑되는 것 확인
- 경기 수원 입력 시 수원시로 매핑되는 것 확인
- 경기 성남 분당 입력 시 분당구로 매핑되는 것 확인
- 충북 청주 상당 입력 시 상당구로 매핑되는 것 확인
- 충북 보은 입력 시 보은군으로 매핑되는 것 확인

### 관련 이슈
- Closes #26