### PR TITLE
[Feat] 법정동 코드 지역 동기화 기능 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,15 +15,16 @@ JWT_EXPIRES_IN=5h
 # Email verification
 EMAIL_VERIFY_EXPIRES_MIN=5
 
-# Resend
+# API KEY
 RESEND_API_KEY=your_resend_api_key
-
-# Public API
 V1365_API_KEY=your_public_api_key
+LEGAL_REGION_API_KEY=your_public_api_key
 
+# API URL
 V1365_API_BASE_URL=http://openapi.1365.go.kr/openapi/service/rest
 
 VOLUNTEER_LIST_PATH=/VolunteerPartcptnService/getVltrSearchWordList
 VOLUNTEER_DETAIL_PATH=/VolunteerPartcptnService/getVltrPartcptnItem
 
 REGION_LIST_PATH=/CodeInquiryService/getAreaCodeInquiryList
+LEGAL_REGION_API_URL=https://apis.data.go.kr/1741000/StanReginCd/getStanReginCdList

--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,11 @@ EMAIL_VERIFY_EXPIRES_MIN=5
 RESEND_API_KEY=your_resend_api_key
 
 # Public API
-VOLUNTEER_API_BASE_URL=http://openapi.1365.go.kr/openapi/service/rest/VolunteerPartcptnService
-VOLUNTEER_LIST_PATH=/getVltrSearchWordList
-VOLUNTEER_DETAIL_PATH=/getVltrPartcptnItem
-VOLUNTEER_API_KEY=your_public_api_key
+V1365_API_KEY=your_public_api_key
+
+V1365_API_BASE_URL=http://openapi.1365.go.kr/openapi/service/rest
+
+VOLUNTEER_LIST_PATH=/VolunteerPartcptnService/getVltrSearchWordList
+VOLUNTEER_DETAIL_PATH=/VolunteerPartcptnService/getVltrPartcptnItem
+
+REGION_LIST_PATH=/CodeInquiryService/getAreaCodeInquiryList

--- a/controllers/region/externalRegionSyncController.js
+++ b/controllers/region/externalRegionSyncController.js
@@ -1,0 +1,9 @@
+import asyncHandler from "../../middleware/asyncHandler.js";
+import { success } from "../../utils/response.js";
+import { sync1365RegionMappings } from "../../services/region/externalRegionSyncService.js";
+
+export const syncExternalRegionMappings = asyncHandler(async (req, res) => {
+  const result = await sync1365RegionMappings();
+
+  return success(res, result, "1365 지역코드 동기화 성공");
+});

--- a/controllers/region/legalRegionSyncController.js
+++ b/controllers/region/legalRegionSyncController.js
@@ -1,0 +1,9 @@
+import asyncHandler from "../../middleware/asyncHandler.js";
+import { success } from "../../utils/response.js";
+import { syncLegalRegions } from "../../services/region/legalRegionSyncService.js";
+
+export const syncLegalRegionCodes = asyncHandler(async (req, res) => {
+  const result = await syncLegalRegions();
+
+  return success(res, result, "법정동 지역 동기화 성공");
+});

--- a/controllers/region/regionController.js
+++ b/controllers/region/regionController.js
@@ -2,32 +2,24 @@ import {
   findAllSidos,
   findChildRegionsByParentCode,
 } from "../../model/region/regionModel.js";
+import asyncHandler from "../../middleware/asyncHandler.js";
 import { success, fail } from "../../utils/response.js";
 
-export const getSidoList = async (req, res) => {
-  try {
-    const sidoList = await findAllSidos();
-    return success(res, sidoList, "시/도 목록 조회 성공");
-  } catch (error) {
-    console.error("시/도 목록 조회 실패:", error);
-    return fail(res, "시/도 목록 조회 중 서버 오류가 발생했습니다.");
+export const getSidoList = asyncHandler(async (req, res) => {
+  const sidoList = await findAllSidos();
+  return success(res, sidoList, "시/도 목록 조회 성공");
+});
+
+export const getSigunguList = asyncHandler(async (req, res) => {
+  const { sidoCode } = req.query;
+
+  if (!sidoCode || String(sidoCode).trim() === "") {
+    return fail(res, "sidoCode는 필수 요청값입니다.", 400);
   }
-};
 
-export const getSigunguList = async (req, res) => {
-  try {
-    const { sidoCode } = req.query;
+  const sigunguList = await findChildRegionsByParentCode(
+    String(sidoCode).trim(),
+  );
 
-    if (!sidoCode || String(sidoCode).trim() === "") {
-      return fail(res, "sidoCode는 필수 요청값입니다.", 400);
-    }
-
-    const sigunguList = await findChildRegionsByParentCode(
-      String(sidoCode).trim(),
-    );
-    return success(res, sigunguList, "시/군/구 목록 조회 성공");
-  } catch (error) {
-    console.error("시/군/구 목록 조회 실패:", error);
-    return fail(res, "시/군/구 목록 조회 중 서버 오류가 발생했습니다.");
-  }
-};
+  return success(res, sigunguList, "시/군/구 목록 조회 성공");
+});

--- a/controllers/volunteer/volunteerController.js
+++ b/controllers/volunteer/volunteerController.js
@@ -1,6 +1,45 @@
-import { findVolunteers } from "../../model/volunteer/volunteerModel.js";
+import { findVolunteers, createVolunteerPerformance } from "../../model/volunteer/volunteerModel.js";
 
 import { success, fail } from "../../utils/response.js";
+
+export const registrationVolunteerPerformance = async (req, res) => {
+  try {
+    const userId = req.user.id;
+
+    const {
+      activityTitle,
+      organizationName,
+      regionCode,
+      place,
+      startDate,
+      endDate,
+    } = req.body;
+
+    const result = await createVolunteerPerformance({
+      userId,
+      activityTitle,
+      organizationName,
+      regionCode,
+      place,
+      startDate,
+      endDate,
+    });
+
+    return success(
+      res, 
+      "봉사 실적 등록 성공", 
+      { insertId: result.insertId }
+    );
+    
+  } catch (err) {
+    console.error("등록 실패", err);
+    return fail(
+      res, 
+      err.message || "등록 실패", 
+      err.status || 500
+    );
+  }
+};
 
 export const getVolunteers = async (req, res) => {
   try {

--- a/middleware/validator/regionConfigValidator.js
+++ b/middleware/validator/regionConfigValidator.js
@@ -27,3 +27,25 @@ export const externalRegionConfigValidator = () => {
     regionListPath,
   };
 };
+
+export const legalRegionConfigValidator = () => {
+  const apiUrl = process.env.LEGAL_REGION_API_URL;
+  const serviceKey = process.env.LEGAL_REGION_API_KEY;
+
+  if (!apiUrl) {
+    throw createConfigError(
+      "LEGAL_REGION_API_URL 환경변수가 설정되지 않았습니다.",
+    );
+  }
+
+  if (!serviceKey) {
+    throw createConfigError(
+      "LEGAL_REGION_API_KEY 환경변수가 설정되지 않았습니다.",
+    );
+  }
+
+  return {
+    apiUrl,
+    serviceKey,
+  };
+};

--- a/middleware/validator/regionConfigValidator.js
+++ b/middleware/validator/regionConfigValidator.js
@@ -1,0 +1,29 @@
+const createConfigError = (message) => {
+  const error = new Error(message);
+  error.status = 500;
+  return error;
+};
+
+export const externalRegionConfigValidator = () => {
+  const baseUrl = process.env.V1365_API_BASE_URL;
+  const serviceKey = process.env.V1365_API_KEY;
+  const regionListPath = process.env.REGION_LIST_PATH;
+
+  if (!baseUrl) {
+    throw createConfigError("V1365_API_BASE_URL이 설정되지 않았습니다.");
+  }
+
+  if (!serviceKey) {
+    throw createConfigError("V1365_API_KEY가 설정되지 않았습니다.");
+  }
+
+  if (!regionListPath) {
+    throw createConfigError("REGION_LIST_PATH가 설정되지 않았습니다.");
+  }
+
+  return {
+    baseUrl,
+    serviceKey,
+    regionListPath,
+  };
+};

--- a/model/region/externalRegionMappingModel.js
+++ b/model/region/externalRegionMappingModel.js
@@ -1,0 +1,52 @@
+import pool from "../../config/db.js";
+
+export const saveExternalRegionMapping = async ({
+  externalRegionCode,
+  externalRegionName,
+  regionCode,
+  isActive = true,
+}) => {
+  const sql = `
+    INSERT INTO volunteer_region_mapping (
+      external_region_code,
+      external_region_name,
+      region_code,
+      is_active,
+      synced_at
+    )
+    VALUES (?, ?, ?, ?, NOW())
+    ON DUPLICATE KEY UPDATE
+      external_region_name = VALUES(external_region_name),
+      region_code = VALUES(region_code),
+      is_active = VALUES(is_active),
+      synced_at = NOW()
+  `;
+
+  await pool.query(sql, [
+    externalRegionCode,
+    externalRegionName,
+    regionCode,
+    isActive,
+  ]);
+};
+
+export const findActiveExternalRegionMappingByCode = async (
+  externalRegionCode,
+) => {
+  const sql = `
+    SELECT
+      id,
+      external_region_code AS externalRegionCode,
+      external_region_name AS externalRegionName,
+      region_code AS regionCode,
+      is_active AS isActive,
+      synced_at AS syncedAt
+    FROM volunteer_region_mapping
+    WHERE external_region_code = ?
+      AND is_active = TRUE
+    LIMIT 1
+  `;
+
+  const [rows] = await pool.query(sql, [externalRegionCode]);
+  return rows[0] || null;
+};

--- a/model/region/regionModel.js
+++ b/model/region/regionModel.js
@@ -72,24 +72,20 @@ export const findSidoByName = async (name) => {
   return findRegionByNameAndLevel({ name, level: 1 });
 };
 
-export const findDescendantRegionByNameUnderSido = async ({
-  name,
-  sidoCode,
-}) => {
+export const upsertRegion = async ({ regionCode, name, level, parentCode }) => {
   const sql = `
-    SELECT
+    INSERT INTO region (
       region_code,
       name,
       level,
       parent_code
-    FROM region
-    WHERE name = ?
-      AND region_code LIKE CONCAT(?, '%')
-      AND region_code <> ?
-    ORDER BY level DESC, CHAR_LENGTH(region_code) DESC
-    LIMIT 1
+    )
+    VALUES (?, ?, ?, ?)
+    ON DUPLICATE KEY UPDATE
+      name = VALUES(name),
+      level = VALUES(level),
+      parent_code = VALUES(parent_code)
   `;
 
-  const [rows] = await pool.query(sql, [name, sidoCode, sidoCode]);
-  return rows[0] || null;
+  await pool.query(sql, [regionCode, name, level, parentCode]);
 };

--- a/model/region/regionModel.js
+++ b/model/region/regionModel.js
@@ -71,3 +71,25 @@ export const findChildRegionByNameAndParentCode = async ({
 export const findSidoByName = async (name) => {
   return findRegionByNameAndLevel({ name, level: 1 });
 };
+
+export const findDescendantRegionByNameUnderSido = async ({
+  name,
+  sidoCode,
+}) => {
+  const sql = `
+    SELECT
+      region_code,
+      name,
+      level,
+      parent_code
+    FROM region
+    WHERE name = ?
+      AND region_code LIKE CONCAT(?, '%')
+      AND region_code <> ?
+    ORDER BY level DESC, CHAR_LENGTH(region_code) DESC
+    LIMIT 1
+  `;
+
+  const [rows] = await pool.query(sql, [name, sidoCode, sidoCode]);
+  return rows[0] || null;
+};

--- a/model/volunteer/volunteerModel.js
+++ b/model/volunteer/volunteerModel.js
@@ -1,5 +1,45 @@
 import conn from "../../config/db.js";
 
+export const createVolunteerPerformance = async (volunteerData) => {
+  const {
+    userId,
+    activityTitle,
+    organizationName,
+    regionCode,
+    place,
+    startDate,
+    endDate,
+  } = volunteerData;
+
+  const sql = `
+        INSERT INTO volunteer_participation (
+            user_id,
+            activity_title,
+            organization_name,
+            region_code,
+            place,
+            start_date,
+            end_date,
+            requested_volunteer_hour,
+            approved_volunteer_hour,
+            created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, 0, 0, NOW())
+    `;
+
+  const [result] = await conn.query(sql, [
+    userId,
+    activityTitle,
+    organizationName,
+    regionCode,
+    place,
+    startDate,
+    endDate,
+  ]);
+
+  return result;
+};
+
 export const findVolunteers = async (query) => {
     const { page, size } = query;
     const pageNum = Number(query.page) || 1;

--- a/routes/region/regionRoutes.js
+++ b/routes/region/regionRoutes.js
@@ -1,16 +1,23 @@
 import express from "express";
+import { isAdmin } from "../../middleware/isAdmin.js";
+import { authMiddleware } from "../../middleware/authMiddleware.js";
 import {
   getSidoList,
   getSigunguList,
 } from "../../controllers/region/regionController.js";
 import { syncExternalRegionMappings } from "../../controllers/region/externalRegionSyncController.js";
-import { isAdmin } from "../../middleware/isAdmin.js";
-import { authMiddleware } from "../../middleware/authMiddleware.js";
+import { syncLegalRegionCodes } from "../../controllers/region/legalRegionSyncController.js";
 
 const router = express.Router();
 
 router.get("/sidos", getSidoList);
 router.get("/sigungu", getSigunguList);
+router.post(
+  "/sync/legal-regions",
+  authMiddleware,
+  isAdmin,
+  syncLegalRegionCodes,
+);
 router.post(
   "/sync/1365-region-mappings",
   authMiddleware,

--- a/routes/region/regionRoutes.js
+++ b/routes/region/regionRoutes.js
@@ -3,10 +3,19 @@ import {
   getSidoList,
   getSigunguList,
 } from "../../controllers/region/regionController.js";
+import { syncExternalRegionMappings } from "../../controllers/region/externalRegionSyncController.js";
+import { isAdmin } from "../../middleware/isAdmin.js";
+import { authMiddleware } from "../../middleware/authMiddleware.js";
 
 const router = express.Router();
 
 router.get("/sidos", getSidoList);
 router.get("/sigungu", getSigunguList);
+router.post(
+  "/sync/1365-region-mappings",
+  authMiddleware,
+  isAdmin,
+  syncExternalRegionMappings,
+);
 
 export default router;

--- a/routes/volunteer/volunteerRoutes.js
+++ b/routes/volunteer/volunteerRoutes.js
@@ -2,10 +2,16 @@ import express from "express";
 const router = express.Router();
 
 import {
-    getVolunteers
+    getVolunteers,
+    registrationVolunteerPerformance
 } from "../../controllers/volunteer/volunteerController.js";
 
 // GET /api/volunteers
 router.get("/", getVolunteers);   // 페이징 + 검색 + 필터 통합
+
+
+// POST /api/register-volunteer
+router.post("/register-volunteer", registrationVolunteerPerformance);
+
 
 export default router;

--- a/services/publicAPI/publicAPIService.js
+++ b/services/publicAPI/publicAPIService.js
@@ -2,10 +2,10 @@ import axios from "axios";
 import { insertVolunteer } from "../../model/publicAPI/publicAPIModel.js";
 import { parseDate } from "../../utils/publicAPIUtil.js";
 
-const BASE_URL = process.env.VOLUNTEER_API_BASE_URL;
+const BASE_URL = process.env.V1365_API_BASE_URL;
 const LIST_PATH = process.env.VOLUNTEER_LIST_PATH;
 const DETAIL_PATH = process.env.VOLUNTEER_DETAIL_PATH;
-const SERVICE_KEY = process.env.VOLUNTEER_API_KEY;
+const SERVICE_KEY = process.env.V1365_API_KEY;
 
 // 봉사활동 목록 삽입
 export const fetchAndSaveVolunteers = async () => {
@@ -14,7 +14,7 @@ export const fetchAndSaveVolunteers = async () => {
     const listRes = await axios.get(`${BASE_URL}${LIST_PATH}`, {
       params: {
         serviceKey: SERVICE_KEY,
-        _type: 'json',
+        _type: "json",
         numOfRows: 50,
       },
     });
@@ -27,20 +27,20 @@ export const fetchAndSaveVolunteers = async () => {
       try {
         // 상세 정보 조회 (progrmCn 등 상세 정보 가져오기 위함)
         const detailRes = await axios.get(`${BASE_URL}${DETAIL_PATH}`, {
-            params: {
-                serviceKey: SERVICE_KEY,
-                progrmRegistNo: item.progrmRegistNo
-            }
+          params: {
+            serviceKey: SERVICE_KEY,
+            progrmRegistNo: item.progrmRegistNo,
+          },
         });
-        
+
         const d = detailRes.data.response.body.items.item;
 
         // 모집 상태 매핑
         const statusMap = {
-            '1': 'CLOSED',  // 모집 대기
-            '2': 'RECRUITING',  // 모집중
-            '3': 'FINISHED' // 모집 완료
-        }
+          1: "CLOSED", // 모집 대기
+          2: "RECRUITING", // 모집중
+          3: "FINISHED", // 모집 완료
+        };
 
         // 데이터 객체 생성
         const volunteer = {
@@ -54,16 +54,19 @@ export const fetchAndSaveVolunteers = async () => {
           start_date: parseDate(d.progrmBgnde, d.actBeginTm),
           end_date: parseDate(d.progrmEndde, d.actEndTm),
           recruit_count: d.rcruitNmpr || 0,
-          volunteer_hour: (d.actEndTm - d.actBeginTm) || 0,
-          status: statusMap[d.progrmStatusSe] || 'FINISHED',
+          volunteer_hour: d.actEndTm - d.actBeginTm || 0,
+          status: statusMap[d.progrmStatusSe] || "FINISHED",
           external_url: d.url,
-          external_id: String(d.progrmRegistNo)
+          external_id: String(d.progrmRegistNo),
         };
 
         await insertVolunteer(volunteer);
         console.log(`저장 완료: ${volunteer.title}`);
       } catch (err) {
-        console.error(`상세 데이터 처리 중 오류 (ID: ${item.progrmRegistNo}):`, err.message);
+        console.error(
+          `상세 데이터 처리 중 오류 (ID: ${item.progrmRegistNo}):`,
+          err.message,
+        );
       }
     }
   } catch (err) {

--- a/services/region/externalRegionSyncService.js
+++ b/services/region/externalRegionSyncService.js
@@ -2,16 +2,16 @@ import axios from "axios";
 import {
   findSidoByName,
   findChildRegionByNameAndParentCode,
-  findDescendantRegionByNameUnderSido,
 } from "../../model/region/regionModel.js";
 import { saveExternalRegionMapping } from "../../model/region/externalRegionMappingModel.js";
 import { buildChildRegionCandidates } from "../../utils/regionLocationParser.js";
+import { isSameMeaningLowerRegionName } from "../../utils/regionNameRules.js";
 
-const REGION_API_BASE_URL = process.env.V1365_API_BASE_URL;
-const REGION_API_SERVICE_KEY = process.env.V1365_API_KEY;
+const BASE_URL = process.env.V1365_API_BASE_URL;
+const SERVICE_KEY = process.env.V1365_API_KEY;
 const REGION_LIST_PATH = process.env.REGION_LIST_PATH;
 
-const CODE_INQUIRY_URL = `${REGION_API_BASE_URL?.replace(/\/$/, "")}/${REGION_LIST_PATH?.replace(/^\//, "")}`;
+const CODE_INQUIRY_URL = `${BASE_URL?.replace(/\/$/, "")}/${REGION_LIST_PATH?.replace(/^\//, "")}`;
 
 const extractItems = (data) => {
   const items = data?.response?.body?.items?.item || [];
@@ -41,70 +41,96 @@ const findMatchedRegionUnderSido = async ({ gugunNm, sidoCode }) => {
     }
   }
 
-  for (const candidate of candidates) {
-    const descendant = await findDescendantRegionByNameUnderSido({
-      name: candidate,
-      sidoCode,
-    });
-
-    if (descendant) {
-      return descendant;
-    }
-  }
-
   return null;
 };
 
-const syncOneRegionItem = async (item) => {
-  const sidoCd = normalizeText(item.sidoCd);
-  const sidoNm = normalizeText(item.sidoNm);
-  const gugunCd = normalizeText(item.gugunCd);
-  const gugunNm = normalizeText(item.gugunNm);
+const resolveRegionFromExternalLocation = async ({ sidoName, sigunguName }) => {
+  const normalizedSidoName = normalizeText(sidoName);
+  const normalizedSigunguName = normalizeText(sigunguName);
 
-  if (!sidoCd || !sidoNm) {
-    return;
+  if (!normalizedSidoName) {
+    return null;
   }
 
-  const sido = await findSidoByName(sidoNm);
+  const sido = await findSidoByName(normalizedSidoName);
 
   if (!sido) {
-    console.warn(`[1365 sync] 시도 매핑 실패: ${sidoNm} (${sidoCd})`);
-    return;
+    console.log(`[1365 sync] 시도 매핑 실패: ${normalizedSidoName}`);
+    return null;
   }
 
-  await saveExternalRegionMapping({
-    externalRegionCode: sidoCd,
-    externalRegionName: sidoNm,
-    regionCode: sido.region_code,
-  });
+  if (!normalizedSigunguName) {
+    return {
+      regionCode: sido.region_code,
+      region: sido,
+    };
+  }
 
-  if (!gugunCd || !gugunNm) {
-    return;
+  if (
+    isSameMeaningLowerRegionName({
+      topLevelName: normalizedSidoName,
+      lowerRegionName: normalizedSigunguName,
+    })
+  ) {
+    return {
+      regionCode: sido.region_code,
+      region: sido,
+    };
   }
 
   const matchedRegion = await findMatchedRegionUnderSido({
-    gugunNm,
+    gugunNm: normalizedSigunguName,
     sidoCode: sido.region_code,
   });
 
   if (!matchedRegion) {
-    console.warn(
-      `[1365 sync] 시군구 매핑 실패: ${sidoNm} ${gugunNm} (${gugunCd})`,
+    console.log(
+      `[1365 sync] 시군구 매핑 실패: ${normalizedSidoName} ${normalizedSigunguName}`,
     );
-    return;
+    return null;
+  }
+
+  return {
+    regionCode: matchedRegion.region_code,
+    region: matchedRegion,
+  };
+};
+
+const syncOneRegionItem = async (item) => {
+  const sidoName = normalizeText(item.sidoNm || item.sido_nm);
+  const sigunguName = normalizeText(item.gugunNm || item.gugun_nm);
+  const externalRegionCode = normalizeText(
+    item.code || item.regionCode || item.gugunCd,
+  );
+
+  if (!externalRegionCode) {
+    console.log("[1365 sync] 외부 코드 없음:", item);
+    return "FAILED";
+  }
+
+  const mappedRegion = await resolveRegionFromExternalLocation({
+    sidoName,
+    sigunguName,
+  });
+
+  if (!mappedRegion) {
+    return "FAILED";
   }
 
   await saveExternalRegionMapping({
-    externalRegionCode: gugunCd,
-    externalRegionName: gugunNm,
-    regionCode: matchedRegion.region_code,
+    externalRegionCode,
+    externalRegionName: `${sidoName} ${sigunguName}`.trim(),
+    regionCode: mappedRegion.regionCode,
+    isActive: true,
   });
+
+  return "SUCCESS";
 };
 
 const fetch1365RegionPage = async ({ pageNo, numOfRows }) => {
   const { data } = await axios.get(CODE_INQUIRY_URL, {
     params: {
-      serviceKey: REGION_API_SERVICE_KEY,
+      serviceKey: SERVICE_KEY,
       type: "json",
       pageNo,
       numOfRows,
@@ -126,13 +152,13 @@ const fetch1365RegionPage = async ({ pageNo, numOfRows }) => {
 };
 
 export const sync1365RegionMappings = async () => {
-  if (!REGION_API_BASE_URL) {
+  if (!BASE_URL) {
     const error = new Error("V1365_API_BASE_URL이 설정되지 않았습니다.");
     error.status = 500;
     throw error;
   }
 
-  if (!REGION_API_SERVICE_KEY) {
+  if (!SERVICE_KEY) {
     const error = new Error("V1365_API_KEY가 설정되지 않았습니다.");
     error.status = 500;
     throw error;
@@ -148,6 +174,8 @@ export const sync1365RegionMappings = async () => {
   let pageNo = 1;
   let totalCount = 0;
   let processedCount = 0;
+  let successCount = 0;
+  let failedCount = 0;
 
   while (true) {
     const data = await fetch1365RegionPage({ pageNo, numOfRows });
@@ -160,8 +188,17 @@ export const sync1365RegionMappings = async () => {
     }
 
     for (const item of items) {
-      await syncOneRegionItem(item);
+      const result = await syncOneRegionItem(item);
+
       processedCount += 1;
+
+      if (result === "SUCCESS") {
+        successCount += 1;
+      }
+
+      if (result === "FAILED") {
+        failedCount += 1;
+      }
     }
 
     if (pageNo * numOfRows >= totalCount) {
@@ -171,9 +208,17 @@ export const sync1365RegionMappings = async () => {
     pageNo += 1;
   }
 
-  return {
+  const result = {
     totalCount,
     processedCount,
+    successCount,
+    failedCount,
     message: "1365 지역코드 매핑 동기화 완료",
   };
+
+  console.log(
+    `[1365 region sync] 원본 ${result.totalCount}건 중 처리 ${result.processedCount}건, 성공 ${result.successCount}건, 실패 ${result.failedCount}건`,
+  );
+
+  return result;
 };

--- a/services/region/externalRegionSyncService.js
+++ b/services/region/externalRegionSyncService.js
@@ -1,0 +1,179 @@
+import axios from "axios";
+import {
+  findSidoByName,
+  findChildRegionByNameAndParentCode,
+  findDescendantRegionByNameUnderSido,
+} from "../../model/region/regionModel.js";
+import { saveExternalRegionMapping } from "../../model/region/externalRegionMappingModel.js";
+import { buildChildRegionCandidates } from "../../utils/regionLocationParser.js";
+
+const REGION_API_BASE_URL = process.env.V1365_API_BASE_URL;
+const REGION_API_SERVICE_KEY = process.env.V1365_API_KEY;
+const REGION_LIST_PATH = process.env.REGION_LIST_PATH;
+
+const CODE_INQUIRY_URL = `${REGION_API_BASE_URL?.replace(/\/$/, "")}/${REGION_LIST_PATH?.replace(/^\//, "")}`;
+
+const extractItems = (data) => {
+  const items = data?.response?.body?.items?.item || [];
+  return Array.isArray(items) ? items : [items];
+};
+
+const extractTotalCount = (data) => {
+  return Number(data?.response?.body?.totalCount || 0);
+};
+
+const normalizeText = (value) => {
+  if (!value) return "";
+  return String(value).trim();
+};
+
+const findMatchedRegionUnderSido = async ({ gugunNm, sidoCode }) => {
+  const candidates = buildChildRegionCandidates(gugunNm);
+
+  for (const candidate of candidates) {
+    const directChild = await findChildRegionByNameAndParentCode({
+      name: candidate,
+      parentCode: sidoCode,
+    });
+
+    if (directChild) {
+      return directChild;
+    }
+  }
+
+  for (const candidate of candidates) {
+    const descendant = await findDescendantRegionByNameUnderSido({
+      name: candidate,
+      sidoCode,
+    });
+
+    if (descendant) {
+      return descendant;
+    }
+  }
+
+  return null;
+};
+
+const syncOneRegionItem = async (item) => {
+  const sidoCd = normalizeText(item.sidoCd);
+  const sidoNm = normalizeText(item.sidoNm);
+  const gugunCd = normalizeText(item.gugunCd);
+  const gugunNm = normalizeText(item.gugunNm);
+
+  if (!sidoCd || !sidoNm) {
+    return;
+  }
+
+  const sido = await findSidoByName(sidoNm);
+
+  if (!sido) {
+    console.warn(`[1365 sync] 시도 매핑 실패: ${sidoNm} (${sidoCd})`);
+    return;
+  }
+
+  await saveExternalRegionMapping({
+    externalRegionCode: sidoCd,
+    externalRegionName: sidoNm,
+    regionCode: sido.region_code,
+  });
+
+  if (!gugunCd || !gugunNm) {
+    return;
+  }
+
+  const matchedRegion = await findMatchedRegionUnderSido({
+    gugunNm,
+    sidoCode: sido.region_code,
+  });
+
+  if (!matchedRegion) {
+    console.warn(
+      `[1365 sync] 시군구 매핑 실패: ${sidoNm} ${gugunNm} (${gugunCd})`,
+    );
+    return;
+  }
+
+  await saveExternalRegionMapping({
+    externalRegionCode: gugunCd,
+    externalRegionName: gugunNm,
+    regionCode: matchedRegion.region_code,
+  });
+};
+
+const fetch1365RegionPage = async ({ pageNo, numOfRows }) => {
+  const { data } = await axios.get(CODE_INQUIRY_URL, {
+    params: {
+      serviceKey: REGION_API_SERVICE_KEY,
+      type: "json",
+      pageNo,
+      numOfRows,
+    },
+  });
+
+  const resultCode = data?.response?.header?.resultCode;
+  const resultMsg = data?.response?.header?.resultMsg;
+
+  if (resultCode !== "00" && resultCode !== "0000") {
+    const error = new Error(
+      `1365 지역코드 조회 실패: ${resultCode} ${resultMsg}`,
+    );
+    error.status = 502;
+    throw error;
+  }
+
+  return data;
+};
+
+export const sync1365RegionMappings = async () => {
+  if (!REGION_API_BASE_URL) {
+    const error = new Error("V1365_API_BASE_URL이 설정되지 않았습니다.");
+    error.status = 500;
+    throw error;
+  }
+
+  if (!REGION_API_SERVICE_KEY) {
+    const error = new Error("V1365_API_KEY가 설정되지 않았습니다.");
+    error.status = 500;
+    throw error;
+  }
+
+  if (!REGION_LIST_PATH) {
+    const error = new Error("REGION_LIST_PATH가 설정되지 않았습니다.");
+    error.status = 500;
+    throw error;
+  }
+
+  const numOfRows = 100;
+  let pageNo = 1;
+  let totalCount = 0;
+  let processedCount = 0;
+
+  while (true) {
+    const data = await fetch1365RegionPage({ pageNo, numOfRows });
+
+    const items = extractItems(data);
+    totalCount = extractTotalCount(data);
+
+    if (items.length === 0) {
+      break;
+    }
+
+    for (const item of items) {
+      await syncOneRegionItem(item);
+      processedCount += 1;
+    }
+
+    if (pageNo * numOfRows >= totalCount) {
+      break;
+    }
+
+    pageNo += 1;
+  }
+
+  return {
+    totalCount,
+    processedCount,
+    message: "1365 지역코드 매핑 동기화 완료",
+  };
+};

--- a/services/region/externalRegionSyncService.js
+++ b/services/region/externalRegionSyncService.js
@@ -6,44 +6,61 @@ import {
 import { saveExternalRegionMapping } from "../../model/region/externalRegionMappingModel.js";
 import { buildChildRegionCandidates } from "../../utils/regionLocationParser.js";
 import { isSameMeaningLowerRegionName } from "../../utils/regionNameRules.js";
+import { externalRegionConfigValidator } from "../../middleware/validator/regionConfigValidator.js";
 
-const BASE_URL = process.env.V1365_API_BASE_URL;
-const SERVICE_KEY = process.env.V1365_API_KEY;
-const REGION_LIST_PATH = process.env.REGION_LIST_PATH;
+const SYNC_STATUS = {
+  SUCCESS: "SUCCESS",
+  FAILED: "FAILED",
+};
 
-const CODE_INQUIRY_URL = `${BASE_URL?.replace(/\/$/, "")}/${REGION_LIST_PATH?.replace(/^\//, "")}`;
+const normalizeText = (value) => String(value || "").trim();
 
-const extractItems = (data) => {
-  const items = data?.response?.body?.items?.item || [];
-  return Array.isArray(items) ? items : [items];
+const buildCodeInquiryUrl = ({ baseUrl, regionListPath }) => {
+  return `${baseUrl.replace(/\/$/, "")}/${regionListPath.replace(/^\//, "")}`;
 };
 
 const extractTotalCount = (data) => {
   return Number(data?.response?.body?.totalCount || 0);
 };
 
-const normalizeText = (value) => {
-  if (!value) return "";
-  return String(value).trim();
+const extractItems = (data) => {
+  const items = data?.response?.body?.items?.item || [];
+  return Array.isArray(items) ? items : [items];
 };
 
-const findMatchedRegionUnderSido = async ({ gugunNm, sidoCode }) => {
-  const candidates = buildChildRegionCandidates(gugunNm);
+const extractExternalRegionItem = (item) => {
+  const sidoName = normalizeText(item?.sidoNm || item?.sido_nm);
+  const sigunguName = normalizeText(item?.gugunNm || item?.gugun_nm);
+  const externalRegionCode = normalizeText(
+    item?.code || item?.regionCode || item?.gugunCd,
+  );
+
+  return {
+    sidoName,
+    sigunguName,
+    externalRegionCode,
+  };
+};
+
+// 특정 시도 아래에서 시군구 후보명을 순회하며 일치하는 지역을 찾는 함수
+const findMatchedRegionUnderSido = async ({ sigunguName, sidoCode }) => {
+  const candidates = buildChildRegionCandidates(sigunguName);
 
   for (const candidate of candidates) {
-    const directChild = await findChildRegionByNameAndParentCode({
+    const region = await findChildRegionByNameAndParentCode({
       name: candidate,
       parentCode: sidoCode,
     });
 
-    if (directChild) {
-      return directChild;
+    if (region) {
+      return region;
     }
   }
 
   return null;
 };
 
+// 외부 API의 시도/시군구명을 기준으로 내부 region 테이블의 지역 정보를 찾는 함수
 const resolveRegionFromExternalLocation = async ({ sidoName, sigunguName }) => {
   const normalizedSidoName = normalizeText(sidoName);
   const normalizedSigunguName = normalizeText(sigunguName);
@@ -59,27 +76,18 @@ const resolveRegionFromExternalLocation = async ({ sidoName, sigunguName }) => {
     return null;
   }
 
-  if (!normalizedSigunguName) {
-    return {
-      regionCode: sido.region_code,
-      region: sido,
-    };
-  }
-
   if (
+    !normalizedSigunguName ||
     isSameMeaningLowerRegionName({
       topLevelName: normalizedSidoName,
       lowerRegionName: normalizedSigunguName,
     })
   ) {
-    return {
-      regionCode: sido.region_code,
-      region: sido,
-    };
+    return sido;
   }
 
   const matchedRegion = await findMatchedRegionUnderSido({
-    gugunNm: normalizedSigunguName,
+    sigunguName: normalizedSigunguName,
     sidoCode: sido.region_code,
   });
 
@@ -90,47 +98,19 @@ const resolveRegionFromExternalLocation = async ({ sidoName, sigunguName }) => {
     return null;
   }
 
-  return {
-    regionCode: matchedRegion.region_code,
-    region: matchedRegion,
-  };
+  return matchedRegion;
 };
 
-const syncOneRegionItem = async (item) => {
-  const sidoName = normalizeText(item.sidoNm || item.sido_nm);
-  const sigunguName = normalizeText(item.gugunNm || item.gugun_nm);
-  const externalRegionCode = normalizeText(
-    item.code || item.regionCode || item.gugunCd,
-  );
-
-  if (!externalRegionCode) {
-    console.log("[1365 sync] 외부 코드 없음:", item);
-    return "FAILED";
-  }
-
-  const mappedRegion = await resolveRegionFromExternalLocation({
-    sidoName,
-    sigunguName,
-  });
-
-  if (!mappedRegion) {
-    return "FAILED";
-  }
-
-  await saveExternalRegionMapping({
-    externalRegionCode,
-    externalRegionName: `${sidoName} ${sigunguName}`.trim(),
-    regionCode: mappedRegion.regionCode,
-    isActive: true,
-  });
-
-  return "SUCCESS";
-};
-
-const fetch1365RegionPage = async ({ pageNo, numOfRows }) => {
-  const { data } = await axios.get(CODE_INQUIRY_URL, {
+// 1365 지역코드 조회 API를 페이지 단위로 호출하는 함수
+const fetch1365RegionPage = async ({
+  pageNo,
+  numOfRows,
+  serviceKey,
+  codeInquiryUrl,
+}) => {
+  const { data } = await axios.get(codeInquiryUrl, {
     params: {
-      serviceKey: SERVICE_KEY,
+      serviceKey,
       type: "json",
       pageNo,
       numOfRows,
@@ -151,70 +131,97 @@ const fetch1365RegionPage = async ({ pageNo, numOfRows }) => {
   return data;
 };
 
+// 외부 지역 item 1건을 내부 region과 매핑해 저장하는 함수
+const syncOneRegionItem = async (item) => {
+  const { sidoName, sigunguName, externalRegionCode } =
+    extractExternalRegionItem(item);
+
+  if (!externalRegionCode) {
+    console.log("[1365 sync] 외부 코드 없음:", item);
+    return SYNC_STATUS.FAILED;
+  }
+
+  const region = await resolveRegionFromExternalLocation({
+    sidoName,
+    sigunguName,
+  });
+
+  if (!region) {
+    return SYNC_STATUS.FAILED;
+  }
+
+  await saveExternalRegionMapping({
+    externalRegionCode,
+    externalRegionName: `${sidoName} ${sigunguName}`.trim(),
+    regionCode: region.region_code,
+    isActive: true,
+  });
+
+  return SYNC_STATUS.SUCCESS;
+};
+
+const createSyncResult = () => {
+  return {
+    totalCount: 0,
+    processedCount: 0,
+    successCount: 0,
+    failedCount: 0,
+    message: "1365 지역코드 매핑 동기화 완료",
+  };
+};
+
+// 단건 동기화 결과에 따라 성공/실패 카운트를 누적하는 함수
+const updateSyncCounts = ({ result, status }) => {
+  result.processedCount += 1;
+
+  if (status === SYNC_STATUS.SUCCESS) {
+    result.successCount += 1;
+    return;
+  }
+
+  result.failedCount += 1;
+};
+
+// 1365 지역코드 전체 데이터를 조회하여 내부 region과 매핑 저장하는 메인 동기화 함수
 export const sync1365RegionMappings = async () => {
-  if (!BASE_URL) {
-    const error = new Error("V1365_API_BASE_URL이 설정되지 않았습니다.");
-    error.status = 500;
-    throw error;
-  }
+  const { baseUrl, serviceKey, regionListPath } =
+    externalRegionConfigValidator();
 
-  if (!SERVICE_KEY) {
-    const error = new Error("V1365_API_KEY가 설정되지 않았습니다.");
-    error.status = 500;
-    throw error;
-  }
-
-  if (!REGION_LIST_PATH) {
-    const error = new Error("REGION_LIST_PATH가 설정되지 않았습니다.");
-    error.status = 500;
-    throw error;
-  }
+  const codeInquiryUrl = buildCodeInquiryUrl({
+    baseUrl,
+    regionListPath,
+  });
 
   const numOfRows = 100;
   let pageNo = 1;
-  let totalCount = 0;
-  let processedCount = 0;
-  let successCount = 0;
-  let failedCount = 0;
+  const result = createSyncResult();
 
   while (true) {
-    const data = await fetch1365RegionPage({ pageNo, numOfRows });
+    const data = await fetch1365RegionPage({
+      pageNo,
+      numOfRows,
+      serviceKey,
+      codeInquiryUrl,
+    });
 
     const items = extractItems(data);
-    totalCount = extractTotalCount(data);
+    result.totalCount = extractTotalCount(data);
 
     if (items.length === 0) {
       break;
     }
 
     for (const item of items) {
-      const result = await syncOneRegionItem(item);
-
-      processedCount += 1;
-
-      if (result === "SUCCESS") {
-        successCount += 1;
-      }
-
-      if (result === "FAILED") {
-        failedCount += 1;
-      }
+      const status = await syncOneRegionItem(item);
+      updateSyncCounts({ result, status });
     }
 
-    if (pageNo * numOfRows >= totalCount) {
+    if (pageNo * numOfRows >= result.totalCount) {
       break;
     }
 
     pageNo += 1;
   }
-
-  const result = {
-    totalCount,
-    processedCount,
-    successCount,
-    failedCount,
-    message: "1365 지역코드 매핑 동기화 완료",
-  };
 
   console.log(
     `[1365 region sync] 원본 ${result.totalCount}건 중 처리 ${result.processedCount}건, 성공 ${result.successCount}건, 실패 ${result.failedCount}건`,

--- a/services/region/legalRegionSyncService.js
+++ b/services/region/legalRegionSyncService.js
@@ -1,0 +1,258 @@
+import axios from "axios";
+import { upsertRegion } from "../../model/region/regionModel.js";
+import { isTopLevelRegionName } from "../../utils/regionNameRules.js";
+
+const API_URL = process.env.LEGAL_REGION_API_URL;
+const SERVICE_KEY = process.env.LEGAL_REGION_API_KEY;
+
+const validateLegalRegionConfig = () => {
+  if (!API_URL) {
+    const error = new Error(
+      "LEGAL_REGION_API_URL 환경변수가 설정되지 않았습니다.",
+    );
+    error.status = 500;
+    throw error;
+  }
+
+  if (!SERVICE_KEY) {
+    const error = new Error(
+      "LEGAL_REGION_SERVICE_KEY 환경변수가 설정되지 않았습니다.",
+    );
+    error.status = 500;
+    throw error;
+  }
+};
+
+const normalizeCode = (value, length) => {
+  return String(value ?? "").padStart(length, "0");
+};
+
+const isSidoItem = ({ sggCd, umdCd, riCd }) => {
+  return sggCd === "000" && umdCd === "000" && riCd === "00";
+};
+
+const isSigunguItem = ({ sggCd, umdCd, riCd }) => {
+  return sggCd !== "000" && umdCd === "000" && riCd === "00";
+};
+
+const mapApiItemToRegion = (item) => {
+  const sidoCd = normalizeCode(item.sido_cd, 2);
+  const sggCd = normalizeCode(item.sgg_cd, 3);
+  const umdCd = normalizeCode(item.umd_cd, 3);
+  const riCd = normalizeCode(item.ri_cd, 2);
+
+  const fullName = String(item.locatadd_nm || "").trim();
+  const lowestName = String(item.locallow_nm || "").trim();
+
+  if (!sidoCd || !fullName) {
+    return null;
+  }
+
+  if (isTopLevelRegionName(lowestName)) {
+    return {
+      regionCode: sidoCd,
+      name: lowestName,
+      level: 1,
+      parentCode: null,
+    };
+  }
+
+  if (isSidoItem({ sggCd, umdCd, riCd })) {
+    return {
+      regionCode: sidoCd,
+      name: fullName,
+      level: 1,
+      parentCode: null,
+    };
+  }
+
+  if (isSigunguItem({ sggCd, umdCd, riCd })) {
+    return {
+      regionCode: `${sidoCd}${sggCd}`,
+      name: lowestName,
+      level: 2,
+      parentCode: sidoCd,
+    };
+  }
+
+  return null;
+};
+
+const extractItemsFromResponse = (data) => {
+  if (!data) {
+    return [];
+  }
+
+  if (Array.isArray(data)) {
+    const rowSection = data.find((item) => Array.isArray(item?.row));
+    return rowSection?.row || [];
+  }
+
+  if (Array.isArray(data?.StanReginCd)) {
+    const rowSection = data.StanReginCd.find((item) =>
+      Array.isArray(item?.row),
+    );
+    return rowSection?.row || [];
+  }
+
+  if (Array.isArray(data?.response?.body?.items?.item)) {
+    return data.response.body.items.item;
+  }
+
+  if (Array.isArray(data?.response?.body?.items)) {
+    return data.response.body.items;
+  }
+
+  if (Array.isArray(data?.items?.item)) {
+    return data.items.item;
+  }
+
+  if (Array.isArray(data?.items)) {
+    return data.items;
+  }
+
+  return [];
+};
+
+const extractMetaFromResponse = (data) => {
+  if (Array.isArray(data)) {
+    const headSection = data.find((item) => Array.isArray(item?.head));
+    const resultInfo = headSection?.head?.[1]?.RESULT || {};
+    const listInfo = headSection?.head?.[0]?.list_total_count || 0;
+
+    return {
+      totalCount: Number(listInfo || 0),
+      pageNo: 1,
+      numOfRows: 0,
+      resultCode: resultInfo.CODE || null,
+      resultMsg: resultInfo.MESSAGE || null,
+    };
+  }
+
+  if (Array.isArray(data?.StanReginCd)) {
+    const headSection = data.StanReginCd.find((item) =>
+      Array.isArray(item?.head),
+    );
+    const resultInfo = headSection?.head?.[1]?.RESULT || {};
+    const listInfo = headSection?.head?.[0]?.list_total_count || 0;
+
+    return {
+      totalCount: Number(listInfo || 0),
+      pageNo: 1,
+      numOfRows: 0,
+      resultCode: resultInfo.CODE || null,
+      resultMsg: resultInfo.MESSAGE || null,
+    };
+  }
+
+  const body = data?.response?.body || data || {};
+
+  return {
+    totalCount: Number(body.totalCount || 0),
+    pageNo: Number(body.pageNo || 1),
+    numOfRows: Number(body.numOfRows || 0),
+    resultCode: body.resultCode || data?.resultCode || null,
+    resultMsg: body.resultMsg || data?.resultMsg || null,
+  };
+};
+
+const fetchLegalRegionPage = async ({ pageNo, numOfRows }) => {
+  const params = {
+    serviceKey: SERVICE_KEY,
+    pageNo,
+    numOfRows,
+    type: "json",
+  };
+
+  const { data } = await axios.get(API_URL, {
+    params,
+  });
+
+  return data;
+};
+
+const deduplicateRegions = (regions) => {
+  const uniqueMap = new Map();
+
+  regions.forEach((region) => {
+    if (!region?.regionCode) {
+      return;
+    }
+
+    uniqueMap.set(region.regionCode, region);
+  });
+
+  return [...uniqueMap.values()];
+};
+
+export const syncLegalRegions = async () => {
+  validateLegalRegionConfig();
+
+  const numOfRows = 1000;
+  let pageNo = 1;
+  let totalCount = 0;
+  let rawItems = [];
+
+  while (true) {
+    const data = await fetchLegalRegionPage({
+      pageNo,
+      numOfRows,
+    });
+
+    const meta = extractMetaFromResponse(data);
+    const items = extractItemsFromResponse(data);
+
+    if (pageNo === 1) {
+      totalCount = meta.totalCount;
+    }
+
+    rawItems = [...rawItems, ...items];
+
+    if (items.length === 0) {
+      break;
+    }
+
+    if (totalCount > 0 && rawItems.length >= totalCount) {
+      break;
+    }
+
+    if (items.length < numOfRows) {
+      break;
+    }
+
+    pageNo += 1;
+  }
+
+  const mappedRegions = rawItems.map(mapApiItemToRegion).filter(Boolean);
+  const uniqueRegions = deduplicateRegions(mappedRegions);
+  const sortedRegions = [...uniqueRegions].sort((a, b) => a.level - b.level);
+
+  let successCount = 0;
+  let failedCount = 0;
+
+  for (const region of sortedRegions) {
+    try {
+      await upsertRegion(region);
+      successCount += 1;
+    } catch (error) {
+      failedCount += 1;
+      console.error(
+        `[legal region sync] 저장 실패: ${region.name} (${region.regionCode}) - ${error.message}`,
+      );
+    }
+  }
+
+  const result = {
+    totalCount,
+    processedCount: sortedRegions.length,
+    successCount,
+    failedCount,
+    message: "법정동 지역 동기화 완료",
+  };
+
+  console.log(
+    `[legal region sync] 원본 ${result.totalCount}건 중 처리 ${result.processedCount}건, 성공 ${result.successCount}건, 실패 ${result.failedCount}건`,
+  );
+
+  return result;
+};

--- a/services/region/legalRegionSyncService.js
+++ b/services/region/legalRegionSyncService.js
@@ -1,31 +1,10 @@
 import axios from "axios";
 import { upsertRegion } from "../../model/region/regionModel.js";
 import { isTopLevelRegionName } from "../../utils/regionNameRules.js";
+import { legalRegionConfigValidator } from "../../middleware/validator/regionConfigValidator.js";
 
-const API_URL = process.env.LEGAL_REGION_API_URL;
-const SERVICE_KEY = process.env.LEGAL_REGION_API_KEY;
-
-const validateLegalRegionConfig = () => {
-  if (!API_URL) {
-    const error = new Error(
-      "LEGAL_REGION_API_URL 환경변수가 설정되지 않았습니다.",
-    );
-    error.status = 500;
-    throw error;
-  }
-
-  if (!SERVICE_KEY) {
-    const error = new Error(
-      "LEGAL_REGION_SERVICE_KEY 환경변수가 설정되지 않았습니다.",
-    );
-    error.status = 500;
-    throw error;
-  }
-};
-
-const normalizeCode = (value, length) => {
-  return String(value ?? "").padStart(length, "0");
-};
+const normalizeCode = (value, length) =>
+  String(value ?? "").padStart(length, "0");
 
 const isSidoItem = ({ sggCd, umdCd, riCd }) => {
   return sggCd === "000" && umdCd === "000" && riCd === "00";
@@ -35,6 +14,7 @@ const isSigunguItem = ({ sggCd, umdCd, riCd }) => {
   return sggCd !== "000" && umdCd === "000" && riCd === "00";
 };
 
+// 법정동 API 응답의 단건 데이터를 우리 region 테이블 구조로 변환하는 함수
 const mapApiItemToRegion = (item) => {
   const sidoCd = normalizeCode(item.sido_cd, 2);
   const sggCd = normalizeCode(item.sgg_cd, 3);
@@ -48,19 +28,10 @@ const mapApiItemToRegion = (item) => {
     return null;
   }
 
-  if (isTopLevelRegionName(lowestName)) {
+  if (isTopLevelRegionName(lowestName) || isSidoItem({ sggCd, umdCd, riCd })) {
     return {
       regionCode: sidoCd,
-      name: lowestName,
-      level: 1,
-      parentCode: null,
-    };
-  }
-
-  if (isSidoItem({ sggCd, umdCd, riCd })) {
-    return {
-      regionCode: sidoCd,
-      name: fullName,
+      name: isTopLevelRegionName(lowestName) ? lowestName : fullName,
       level: 1,
       parentCode: null,
     };
@@ -78,6 +49,7 @@ const mapApiItemToRegion = (item) => {
   return null;
 };
 
+// 여러 형태의 법정동 API 응답 구조에서 row 목록만 공통으로 추출하는 함수
 const extractItemsFromResponse = (data) => {
   if (!data) {
     return [];
@@ -156,16 +128,20 @@ const extractMetaFromResponse = (data) => {
   };
 };
 
-const fetchLegalRegionPage = async ({ pageNo, numOfRows }) => {
-  const params = {
-    serviceKey: SERVICE_KEY,
-    pageNo,
-    numOfRows,
-    type: "json",
-  };
-
-  const { data } = await axios.get(API_URL, {
-    params,
+// 법정동 API를 페이지 단위로 호출하는 함수
+const fetchLegalRegionPage = async ({
+  pageNo,
+  numOfRows,
+  apiUrl,
+  serviceKey,
+}) => {
+  const { data } = await axios.get(apiUrl, {
+    params: {
+      serviceKey,
+      pageNo,
+      numOfRows,
+      type: "json",
+    },
   });
 
   return data;
@@ -174,19 +150,35 @@ const fetchLegalRegionPage = async ({ pageNo, numOfRows }) => {
 const deduplicateRegions = (regions) => {
   const uniqueMap = new Map();
 
-  regions.forEach((region) => {
+  for (const region of regions) {
     if (!region?.regionCode) {
-      return;
+      continue;
     }
 
     uniqueMap.set(region.regionCode, region);
-  });
+  }
 
   return [...uniqueMap.values()];
 };
 
+const createSyncResult = ({
+  totalCount,
+  processedCount,
+  successCount,
+  failedCount,
+}) => {
+  return {
+    totalCount,
+    processedCount,
+    successCount,
+    failedCount,
+    message: "법정동 지역 동기화 완료",
+  };
+};
+
+// 법정동 전체 데이터를 조회해 region 테이블에 저장하는 메인 동기화 함수
 export const syncLegalRegions = async () => {
-  validateLegalRegionConfig();
+  const { apiUrl, serviceKey } = legalRegionConfigValidator();
 
   const numOfRows = 1000;
   let pageNo = 1;
@@ -197,6 +189,8 @@ export const syncLegalRegions = async () => {
     const data = await fetchLegalRegionPage({
       pageNo,
       numOfRows,
+      apiUrl,
+      serviceKey,
     });
 
     const meta = extractMetaFromResponse(data);
@@ -208,15 +202,11 @@ export const syncLegalRegions = async () => {
 
     rawItems = [...rawItems, ...items];
 
-    if (items.length === 0) {
-      break;
-    }
-
-    if (totalCount > 0 && rawItems.length >= totalCount) {
-      break;
-    }
-
-    if (items.length < numOfRows) {
+    if (
+      items.length === 0 ||
+      (totalCount > 0 && rawItems.length >= totalCount) ||
+      items.length < numOfRows
+    ) {
       break;
     }
 
@@ -242,13 +232,12 @@ export const syncLegalRegions = async () => {
     }
   }
 
-  const result = {
+  const result = createSyncResult({
     totalCount,
     processedCount: sortedRegions.length,
     successCount,
     failedCount,
-    message: "법정동 지역 동기화 완료",
-  };
+  });
 
   console.log(
     `[legal region sync] 원본 ${result.totalCount}건 중 처리 ${result.processedCount}건, 성공 ${result.successCount}건, 실패 ${result.failedCount}건`,

--- a/services/region/regionService.js
+++ b/services/region/regionService.js
@@ -19,13 +19,13 @@ const buildResolveResult = ({ region = null, sourceText = "" }) => {
 
 const findMatchedChildRegion = async ({ candidates, parentCode }) => {
   for (const candidate of candidates) {
-    const region = await findChildRegionByNameAndParentCode({
+    const matchedRegion = await findChildRegionByNameAndParentCode({
       name: candidate,
       parentCode,
     });
 
-    if (region) {
-      return region;
+    if (matchedRegion) {
+      return matchedRegion;
     }
   }
 

--- a/utils/regionNameRules.js
+++ b/utils/regionNameRules.js
@@ -1,0 +1,41 @@
+export const TOP_LEVEL_REGION_SUFFIXES = [
+  "특별시",
+  "광역시",
+  "특별자치시",
+  "도",
+  "특별자치도",
+];
+
+export const isTopLevelRegionName = (name = "") => {
+  return TOP_LEVEL_REGION_SUFFIXES.some((suffix) => name.endsWith(suffix));
+};
+
+export const isSameMeaningLowerRegionName = ({
+  topLevelName = "",
+  lowerRegionName = "",
+}) => {
+  const normalizedTopLevelName = String(topLevelName).trim();
+  const normalizedLowerRegionName = String(lowerRegionName).trim();
+
+  if (!normalizedTopLevelName || !normalizedLowerRegionName) {
+    return false;
+  }
+
+  if (!isTopLevelRegionName(normalizedTopLevelName)) {
+    return false;
+  }
+
+  const baseTopLevelName = normalizedTopLevelName
+    .replace(/특별자치시$/, "")
+    .replace(/특별시$/, "")
+    .replace(/광역시$/, "")
+    .replace(/특별자치도$/, "")
+    .replace(/도$/, "");
+
+  const baseLowerRegionName = normalizedLowerRegionName
+    .replace(/시$/, "")
+    .replace(/군$/, "")
+    .replace(/구$/, "");
+
+  return baseTopLevelName === baseLowerRegionName;
+};


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 법정동 코드 Open API를 연동해 지역 정보를 동기화하는 기능을 추가했습니다.
- 법정동 원본 데이터에서 시/도, 시/군/구 단위만 추출해 region 테이블에 저장하도록 구현했습니다.
- 지역코드 기준 upsert 로직을 적용해 기존 데이터와 중복 저장되지 않도록 처리했습니다.
- 수동 실행 API와 서버 시작 시 자동 동기화 흐름을 연결했습니다.
- 법정동 코드 API 연동에 필요한 환경변수를 추가했습니다.

### 테스트 결과
- 동기화 API 호출 시 법정동 코드 데이터 조회 성공 확인
- 시/도, 시/군/구 데이터만 저장되는지 확인
- 기존 지역코드가 있을 때 중복 insert 없이 upsert 되는지 확인
- 서버 시작 시 자동 동기화가 정상 실행되는지 확인
- 동기화 결과로 전체 건수, 성공 건수, 실패 건수가 출력되는지 확인

### 관련 이슈
- Closes #12             