### PR TITLE
[Feat] 봉사활동 지역코드 매핑 및 지역명 조회 기능 반영

### DIFF
--- a/controllers/publicAPI/publicAPIController.js
+++ b/controllers/publicAPI/publicAPIController.js
@@ -1,0 +1,13 @@
+import { fetchAndSaveVolunteers } from "../../services/publicAPI/publicAPIService.js";
+import { success, fail } from "../../utils/response.js";
+
+export const syncVolunteers = async (req, res) => {
+  try {
+    await fetchAndSaveVolunteers();
+
+    return success(res, null, "봉사활동 동기화 성공", 200);
+  } catch (err) {
+    console.error("봉사활동 동기화 실패", err);
+    return fail(res, err.message || "봉사활동 동기화 실패", err.status || 500);
+  }
+};

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ import authRoutes from "./routes/auth/authRoutes.js";
 import regionRoutes from "./routes/region/regionRoutes.js";
 import volunteerStatsRoutes from "./routes/volunteerStats/volunteerStatsRoutes.js";
 import rankRoutes from "./routes/rank/rankRoutes.js";
+import publicAPIRouter from "./routes/publicAPI/publicAPIRouter.js";
 
 import certificateRoutes from "./routes/certificate/certificateRoutes.js";
 import errorHandler from "./middleware/errorHandler.js";
@@ -24,7 +25,8 @@ app.use("/api/regions", regionRoutes);
 app.use("/api/volunteer-stats", volunteerStatsRoutes);
 app.use("/uploads", express.static(path.join(process.cwd(), "uploads")));
 app.use("/api/certificates", certificateRoutes);
-app.use("/api/rank", rankRoutes)
+app.use("/api/rank", rankRoutes);
+app.use("/api/volunteers", publicAPIRouter);
 
 // 에러 핸들러 (항상 마지막!)
 app.use(errorHandler);

--- a/model/publicAPI/publicAPIModel.js
+++ b/model/publicAPI/publicAPIModel.js
@@ -8,6 +8,7 @@ export const insertVolunteer = async (v) => {
         description,
         volunteer_type,
         organization_name,
+        region_code,
         place,
         recruit_start_at,
         recruit_end_at,
@@ -15,15 +16,17 @@ export const insertVolunteer = async (v) => {
         end_date,
         recruit_count,
         volunteer_hour,
-        status, external_url,
+        status,
+        external_url,
         external_id
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON DUPLICATE KEY UPDATE
         title = VALUES(title),
         description = VALUES(description),
         volunteer_type = VALUES(volunteer_type),
         organization_name = VALUES(organization_name),
+        region_code = VALUES(region_code),
         place = VALUES(place),
         recruit_start_at = VALUES(recruit_start_at),
         recruit_end_at = VALUES(recruit_end_at),
@@ -40,6 +43,7 @@ export const insertVolunteer = async (v) => {
     v.description,
     v.volunteer_type,
     v.organization_name,
+    v.region_code,
     v.place,
     v.recruit_start_at,
     v.recruit_end_at,

--- a/model/region/externalRegionMappingModel.js
+++ b/model/region/externalRegionMappingModel.js
@@ -50,3 +50,15 @@ export const findActiveExternalRegionMappingByCode = async (
   const [rows] = await pool.query(sql, [externalRegionCode]);
   return rows[0] || null;
 };
+
+export const findRegionCodeBy1365Code = async (externalCode) => {
+  const query = `
+    SELECT region_code
+    FROM volunteer_region_mapping
+    WHERE external_region_code = ?
+    LIMIT 1
+  `;
+
+  const [rows] = await pool.query(query, [externalCode]);
+  return rows[0]?.region_code || null;
+};

--- a/model/volunteer/volunteerModel.js
+++ b/model/volunteer/volunteerModel.js
@@ -1,5 +1,13 @@
 import conn from "../../config/db.js";
 
+const formatRegionName = ({ level, region_name, parent_name }) => {
+  if (!region_name) return null;
+  if (Number(level) === 1) return region_name;
+  if (Number(level) === 2 && parent_name)
+    return `${parent_name} ${region_name}`;
+  return region_name;
+};
+
 export const createVolunteerPerformance = async (volunteerData) => {
   const {
     userId,
@@ -12,20 +20,20 @@ export const createVolunteerPerformance = async (volunteerData) => {
   } = volunteerData;
 
   const sql = `
-        INSERT INTO volunteer_participation (
-            user_id,
-            activity_title,
-            organization_name,
-            region_code,
-            place,
-            start_date,
-            end_date,
-            requested_volunteer_hour,
-            approved_volunteer_hour,
-            created_at
-        )
-        VALUES (?, ?, ?, ?, ?, ?, ?, 0, 0, NOW())
-    `;
+    INSERT INTO volunteer_participation (
+      user_id,
+      activity_title,
+      organization_name,
+      region_code,
+      place,
+      start_date,
+      end_date,
+      requested_volunteer_hour,
+      approved_volunteer_hour,
+      created_at
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, 0, 0, NOW())
+  `;
 
   const [result] = await conn.query(sql, [
     userId,
@@ -41,73 +49,110 @@ export const createVolunteerPerformance = async (volunteerData) => {
 };
 
 export const findVolunteers = async (query) => {
-    const { page, size } = query;
-    const pageNum = Number(query.page) || 1;
-    const sizeNum = Number(query.size) || 10;
+  const pageNum = Number(query.page) || 1;
+  const sizeNum = Number(query.size) || 10;
+  const offset = (pageNum - 1) * sizeNum;
 
-    const offset = (pageNum - 1) * sizeNum;
-
-    let sql = `
-    SELECT id, title, description, volunteer_type, organization_name, region_code, place, recruit_start_at, recruit_end_at, start_date, end_date, recruit_count, volunteer_hour, status
-    FROM volunteer
+  let sql = `
+    SELECT
+      v.id,
+      v.title,
+      v.description,
+      v.volunteer_type,
+      v.organization_name,
+      v.region_code,
+      v.place,
+      v.recruit_start_at,
+      v.recruit_end_at,
+      v.start_date,
+      v.end_date,
+      v.recruit_count,
+      v.volunteer_hour,
+      v.status,
+      r.name AS region_name,
+      r.level,
+      p.name AS parent_name
+    FROM volunteer v
+    LEFT JOIN region r
+      ON v.region_code = r.region_code
+    LEFT JOIN region p
+      ON r.parent_code = p.region_code
     WHERE 1=1
-    `;
+  `;
 
-    let countSql = "SELECT COUNT(*) AS total FROM volunteer WHERE 1=1";
+  let countSql = `
+    SELECT COUNT(*) AS total
+    FROM volunteer v
+    WHERE 1=1
+  `;
 
-    const params = [];
-    const countParams = [];
+  const params = [];
+  const countParams = [];
 
-    // 검색 (LIKE로 구현, 제목과 내용만)
-    if (query.keyword) {
-        sql += " AND (title LIKE ? OR description LIKE ?)";
-        countSql += " AND (title LIKE ? OR description LIKE ?)";
+  if (query.keyword) {
+    sql += " AND (v.title LIKE ? OR v.description LIKE ?)";
+    countSql += " AND (v.title LIKE ? OR v.description LIKE ?)";
 
-        const keyword = `%${query.keyword}%`;
-        params.push(keyword, keyword);
-        countParams.push(keyword, keyword);
-    }
+    const keyword = `%${query.keyword}%`;
+    params.push(keyword, keyword);
+    countParams.push(keyword, keyword);
+  }
 
-    // 필터 (LIKE X, 정확 비교)
-    if (query.region_code) {
-        sql += " AND region_code = ?";
-        countSql += " AND region_code = ?";
+  if (query.region_code) {
+    sql += " AND v.region_code = ?";
+    countSql += " AND v.region_code = ?";
 
-        params.push(query.region_code);
-        countParams.push(query.region_code);
-    }
+    params.push(query.region_code);
+    countParams.push(query.region_code);
+  }
 
-    if (query.volunteer_type) {
-        sql += " AND volunteer_type = ?";
-        countSql += " AND volunteer_type = ?";
+  if (query.volunteer_type) {
+    sql += " AND v.volunteer_type = ?";
+    countSql += " AND v.volunteer_type = ?";
 
-        params.push(query.volunteer_type);
-        countParams.push(query.volunteer_type);
-    }
+    params.push(query.volunteer_type);
+    countParams.push(query.volunteer_type);
+  }
 
-    if (query.status) {
-        sql += " AND status = ?";
-        countSql += " AND status = ?";
+  if (query.status) {
+    sql += " AND v.status = ?";
+    countSql += " AND v.status = ?";
 
-        params.push(query.status);
-        countParams.push(query.status);
-    }
+    params.push(query.status);
+    countParams.push(query.status);
+  }
 
-    // 정렬 + 페이징
-    sql += " ORDER BY id DESC LIMIT ?, ?";
-    params.push(offset, sizeNum);
+  sql += " ORDER BY v.id DESC LIMIT ?, ?";
+  params.push(offset, sizeNum);
 
-    const [rows] = await conn.query(sql, params);
-    const [countRows] = await conn.query(countSql, countParams);
+  const [rows] = await conn.query(sql, params);
+  const [countRows] = await conn.query(countSql, countParams);
 
-    const total = countRows[0].total;
+  const total = countRows[0].total;
 
-    return {
-        page: pageNum,
-        size: sizeNum,
-        total,
-        totalPages: Math.ceil(total / size),
-        data: rows
-    };
+  const data = rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    description: row.description,
+    volunteer_type: row.volunteer_type,
+    organization_name: row.organization_name,
+    region_code: row.region_code,
+    region_name: formatRegionName(row),
+    place: row.place,
+    recruit_start_at: row.recruit_start_at,
+    recruit_end_at: row.recruit_end_at,
+    start_date: row.start_date,
+    end_date: row.end_date,
+    recruit_count: row.recruit_count,
+    volunteer_hour: row.volunteer_hour,
+    status: row.status,
+  }));
+
+  return {
+    page: pageNum,
+    size: sizeNum,
+    total,
+    totalPages: Math.ceil(total / sizeNum),
+    data,
+  };
 };
-

--- a/routes/publicAPI/publicAPIRouter.js
+++ b/routes/publicAPI/publicAPIRouter.js
@@ -1,0 +1,10 @@
+import express from "express";
+import { syncVolunteers } from "../../controllers/publicAPI/publicAPIController.js";
+
+const router = express.Router();
+
+// 봉사활동 목록 동기화
+// POST /api/volunteers/sync
+router.post("/sync", syncVolunteers);
+
+export default router;

--- a/services/publicAPI/publicAPIService.js
+++ b/services/publicAPI/publicAPIService.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { insertVolunteer } from "../../model/publicAPI/publicAPIModel.js";
 import { parseDate } from "../../utils/publicAPIUtil.js";
+import { findRegionCodeBy1365Code } from "../../model/region/externalRegionMappingModel.js";
 
 const BASE_URL = process.env.V1365_API_BASE_URL;
 const LIST_PATH = process.env.VOLUNTEER_LIST_PATH;
@@ -42,12 +43,19 @@ export const fetchAndSaveVolunteers = async () => {
           3: "FINISHED", // 모집 완료
         };
 
+        const externalRegionCode = String(d.gugunCd || d.sidoCd || "").trim();
+
+        const regionCode = externalRegionCode
+          ? await findRegionCodeBy1365Code(externalRegionCode)
+          : null;
+
         // 데이터 객체 생성
         const volunteer = {
           title: d.progrmSj || "",
           description: d.progrmCn || "",
           volunteer_type: d.srvcClCode || "",
           organization_name: d.mnnstNm || "",
+          region_code: regionCode,
           place: d.actPlace || "",
           recruit_start_at: parseDate(d.noticeBgnde),
           recruit_end_at: parseDate(d.noticeEndde),


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 봉사활동 저장 시 1365 지역코드를 내부 법정동 코드로 매핑하도록 반영했습니다.
- 봉사활동 목록 조회 시 지역 코드를 기반으로 지역명을 함께 반환하도록 수정했습니다.
- 봉사활동 동기화 테스트용 컨트롤러와 라우터를 추가했습니다.

### 테스트 결과
- 봉사활동 동기화 API 호출 후 데이터 저장 확인
- 저장된 봉사활동의 region_code가 법정동 코드로 반영되는 것 확인
- 봉사활동 목록 조회 시 region_name이 함께 반환되는 것 확인

### 관련 이슈   