### PR TITLE
[Fix] # 랭킹 조회 시 부모 지역 맵핑 설정

### DIFF
--- a/model/rank/rankModel.js
+++ b/model/rank/rankModel.js
@@ -15,6 +15,7 @@ export const getNationalTop100 = async () => {
     LEFT JOIN volunteer_participation vp
       ON vp.user_id = u.id
       AND vp.participation_status = 'APPROVED'
+    WHERE u.role = 'USER'
     GROUP BY u.id, u.nickname, u.region_code
     ORDER BY rank_position ASC
     LIMIT 100
@@ -34,21 +35,25 @@ export const getRegionalTop100 = async (regionCode) => {
       u.region_code,
       COALESCE(SUM(vp.approved_volunteer_hour), 0) AS total_hours,
       RANK() OVER (
-        PARTITION BY u.region_code
         ORDER BY COALESCE(SUM(vp.approved_volunteer_hour), 0) DESC
       ) AS rank_position
     FROM users u
     LEFT JOIN volunteer_participation vp
       ON vp.user_id = u.id
       AND vp.participation_status = 'APPROVED'
-    WHERE u.region_code = ?
+    JOIN region r
+      ON r.region_code = u.region_code
+    WHERE u.role = 'USER'
+      AND (
+        u.region_code = ?          -- 시군구 코드로 직접 매칭
+        OR r.parent_code = ?       -- 시도 코드로 하위 시군구 전체 포함
+      )
     GROUP BY u.id, u.nickname, u.region_code
     ORDER BY rank_position ASC
     LIMIT 100
   `;
 
-  const [rows] = await conn.execute(sql, [regionCode]);
-  
+  const [rows] = await conn.execute(sql, [regionCode, regionCode]);
   return rows;
 };
 
@@ -90,20 +95,24 @@ export const getMyRegionalRank = async (userId, regionCode) => {
         u.region_code,
         COALESCE(SUM(vp.approved_volunteer_hour), 0) AS total_hours,
         RANK() OVER (
-          PARTITION BY u.region_code
           ORDER BY COALESCE(SUM(vp.approved_volunteer_hour), 0) DESC
         ) AS rank_position
       FROM users u
       LEFT JOIN volunteer_participation vp
         ON vp.user_id = u.id
         AND vp.participation_status = 'APPROVED'
-      WHERE u.region_code = ?
+      JOIN region r
+        ON r.region_code = u.region_code
+      WHERE u.role = 'USER'
+        AND (
+          u.region_code = ?        -- 시군구 직접 매칭
+          OR r.parent_code = ?     -- 시도 하위 전체 포함
+        )
       GROUP BY u.id, u.nickname, u.region_code
     ) ranked
     WHERE user_id = ?
   `;
 
-  const [rows] = await conn.execute(sql, [regionCode, userId]);
-  
+  const [rows] = await conn.execute(sql, [regionCode, regionCode, userId]);
   return rows[0] ?? null;
 };


### PR DESCRIPTION
## 📌 개요
<!-- 어떤 변경인지 한 줄 요약 -->
- 랭킹 조회 시 부모 지역 조회 할 때 자식 지역에 속한 유저가 집계되지 않는 버그를 수정하였습니다
- 관리자가 랭킹에 집계 되지 않도록 수정하였습니다

---

## ✨ 작업 내용
<!-- 무엇을 했는지 구체적으로 작성 -->
- 모델에 `u.role = USER` 조건을 추가하였습니다
- 아래 조건을 추가하여 부모 지역 조회 시 모든 자식지역을 조회하도록 하였습니다
 ```sql
AND (
  u.region_code = ?    -- 시군구 코드 그대로 넘겨도 동작
  OR r.parent_code = ? -- 시도 코드 넘기면 하위 시군구 사용자 전부 포함
) 
```


---

## 🔥 변경 사항
<!-- 기존 코드 대비 달라진 점 (새 기능 작성 시 필요 X) -->
- 관리자가 랭킹에 집계되지 않습니다
- 이제 부모 지역 조회 시 자식 지역 내 유저가 모두 집계됩니다

---

## 🧪 테스트
<!-- 어떻게 테스트했는지 -->
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 에러 없이 정상 동작 확인

---

## 🔗 관련 이슈
<!-- 자동 연결됨 -->
Close #

---

## ⚠️ 주의사항
<!-- 배포 시 주의할 점 -->
- 