### PR TITLE
[Refactor] 지역 매핑 캐시 적용 및 동기화 성능 최적화

### DIFF
--- a/model/region/regionModel.js
+++ b/model/region/regionModel.js
@@ -89,3 +89,12 @@ export const upsertRegion = async ({ regionCode, name, level, parentCode }) => {
 
   await pool.query(sql, [regionCode, name, level, parentCode]);
 };
+
+export const findAllRegions = async () => {
+  const sql = `
+    SELECT region_code, name, level, parent_code
+    FROM region
+  `;
+  const [rows] = await pool.query(sql);
+  return rows;
+};

--- a/services/region/externalRegionSyncService.js
+++ b/services/region/externalRegionSyncService.js
@@ -1,10 +1,10 @@
 import axios from "axios";
+import { findAllRegions } from "../../model/region/regionModel.js";
 import {
-  findSidoByName,
-  findChildRegionByNameAndParentCode,
-} from "../../model/region/regionModel.js";
+  buildRegionCache,
+  resolveRegionFromLocationText,
+} from "./regionService.js";
 import { saveExternalRegionMapping } from "../../model/region/externalRegionMappingModel.js";
-import { buildChildRegionCandidates } from "../../utils/regionLocationParser.js";
 import { isSameMeaningLowerRegionName } from "../../utils/regionNameRules.js";
 import { externalRegionConfigValidator } from "../../middleware/validator/regionConfigValidator.js";
 
@@ -42,26 +42,16 @@ const extractExternalRegionItem = (item) => {
   };
 };
 
-// 특정 시도 아래에서 시군구 후보명을 순회하며 일치하는 지역을 찾는 함수
-const findMatchedRegionUnderSido = async ({ sigunguName, sidoCode }) => {
-  const candidates = buildChildRegionCandidates(sigunguName);
-
-  for (const candidate of candidates) {
-    const region = await findChildRegionByNameAndParentCode({
-      name: candidate,
-      parentCode: sidoCode,
-    });
-
-    if (region) {
-      return region;
-    }
-  }
-
-  return null;
+const buildExternalLocationText = ({ sidoName, sigunguName }) => {
+  return [sidoName, sigunguName].filter(Boolean).join(" ").trim();
 };
 
 // 외부 API의 시도/시군구명을 기준으로 내부 region 테이블의 지역 정보를 찾는 함수
-const resolveRegionFromExternalLocation = async ({ sidoName, sigunguName }) => {
+const resolveRegionFromExternalLocation = ({
+  sidoName,
+  sigunguName,
+  regionCache,
+}) => {
   const normalizedSidoName = normalizeText(sidoName);
   const normalizedSigunguName = normalizeText(sigunguName);
 
@@ -69,9 +59,15 @@ const resolveRegionFromExternalLocation = async ({ sidoName, sigunguName }) => {
     return null;
   }
 
-  const sido = await findSidoByName(normalizedSidoName);
+  const sourceText = buildExternalLocationText({
+    sidoName: normalizedSidoName,
+    sigunguName: normalizedSigunguName,
+  });
 
-  if (!sido) {
+  const resolved = resolveRegionFromLocationText(sourceText, regionCache);
+  const region = resolved?.region || null;
+
+  if (!region) {
     console.log(`[1365 sync] 시도 매핑 실패: ${normalizedSidoName}`);
     return null;
   }
@@ -83,22 +79,21 @@ const resolveRegionFromExternalLocation = async ({ sidoName, sigunguName }) => {
       lowerRegionName: normalizedSigunguName,
     })
   ) {
-    return sido;
+    return region;
   }
 
-  const matchedRegion = await findMatchedRegionUnderSido({
-    sigunguName: normalizedSigunguName,
-    sidoCode: sido.region_code,
-  });
+  if (String(region.region_code) === String(resolved?.regionCode || "")) {
+    const isTopLevel = Number(region.level) === 1;
 
-  if (!matchedRegion) {
-    console.log(
-      `[1365 sync] 시군구 매핑 실패: ${normalizedSidoName} ${normalizedSigunguName}`,
-    );
-    return null;
+    if (isTopLevel) {
+      console.log(
+        `[1365 sync] 시군구 매핑 실패: ${normalizedSidoName} ${normalizedSigunguName}`,
+      );
+      return null;
+    }
   }
 
-  return matchedRegion;
+  return region;
 };
 
 // 1365 지역코드 조회 API를 페이지 단위로 호출하는 함수
@@ -132,7 +127,7 @@ const fetch1365RegionPage = async ({
 };
 
 // 외부 지역 item 1건을 내부 region과 매핑해 저장하는 함수
-const syncOneRegionItem = async (item) => {
+const syncOneRegionItem = async ({ item, regionCache }) => {
   const { sidoName, sigunguName, externalRegionCode } =
     extractExternalRegionItem(item);
 
@@ -141,9 +136,10 @@ const syncOneRegionItem = async (item) => {
     return SYNC_STATUS.FAILED;
   }
 
-  const region = await resolveRegionFromExternalLocation({
+  const region = resolveRegionFromExternalLocation({
     sidoName,
     sigunguName,
+    regionCache,
   });
 
   if (!region) {
@@ -184,6 +180,8 @@ const updateSyncCounts = ({ result, status }) => {
 
 // 1365 지역코드 전체 데이터를 조회하여 내부 region과 매핑 저장하는 메인 동기화 함수
 export const sync1365RegionMappings = async () => {
+  console.log("[1365 region sync] 동기화 시작");
+  console.time("소요 시간");
   const { baseUrl, serviceKey, regionListPath } =
     externalRegionConfigValidator();
 
@@ -191,6 +189,9 @@ export const sync1365RegionMappings = async () => {
     baseUrl,
     regionListPath,
   });
+
+  const allRegions = await findAllRegions();
+  const regionCache = buildRegionCache(allRegions);
 
   const numOfRows = 100;
   let pageNo = 1;
@@ -212,7 +213,7 @@ export const sync1365RegionMappings = async () => {
     }
 
     for (const item of items) {
-      const status = await syncOneRegionItem(item);
+      const status = await syncOneRegionItem({ item, regionCache });
       updateSyncCounts({ result, status });
     }
 
@@ -226,6 +227,7 @@ export const sync1365RegionMappings = async () => {
   console.log(
     `[1365 region sync] 원본 ${result.totalCount}건 중 처리 ${result.processedCount}건, 성공 ${result.successCount}건, 실패 ${result.failedCount}건`,
   );
+  console.timeEnd("소요 시간");
 
   return result;
 };

--- a/services/region/legalRegionSyncService.js
+++ b/services/region/legalRegionSyncService.js
@@ -89,11 +89,17 @@ const extractItemsFromResponse = (data) => {
 const extractMetaFromResponse = (data) => {
   if (Array.isArray(data)) {
     const headSection = data.find((item) => Array.isArray(item?.head));
-    const resultInfo = headSection?.head?.[1]?.RESULT || {};
-    const listInfo = headSection?.head?.[0]?.list_total_count || 0;
+    const headArray = headSection?.head || [];
+    const countInfo =
+      headArray.find(
+        (h) => h.list_total_count !== undefined || h.totalCount !== undefined,
+      ) || {};
+    const resultInfo = headArray.find((h) => h.RESULT)?.RESULT || {};
 
     return {
-      totalCount: Number(listInfo || 0),
+      totalCount: Number(
+        countInfo.totalCount || countInfo.list_total_count || 0,
+      ),
       pageNo: 1,
       numOfRows: 0,
       resultCode: resultInfo.CODE || null,
@@ -105,11 +111,18 @@ const extractMetaFromResponse = (data) => {
     const headSection = data.StanReginCd.find((item) =>
       Array.isArray(item?.head),
     );
-    const resultInfo = headSection?.head?.[1]?.RESULT || {};
-    const listInfo = headSection?.head?.[0]?.list_total_count || 0;
+    const headArray = headSection?.head || [];
+
+    const countInfo =
+      headArray.find(
+        (h) => h.list_total_count !== undefined || h.totalCount !== undefined,
+      ) || {};
+    const resultInfo = headArray.find((h) => h.RESULT)?.RESULT || {};
 
     return {
-      totalCount: Number(listInfo || 0),
+      totalCount: Number(
+        countInfo.totalCount || countInfo.list_total_count || 0,
+      ),
       pageNo: 1,
       numOfRows: 0,
       resultCode: resultInfo.CODE || null,
@@ -117,14 +130,14 @@ const extractMetaFromResponse = (data) => {
     };
   }
 
-  const body = data?.response?.body || data || {};
+  const root = data?.response?.body || data || {};
 
   return {
-    totalCount: Number(body.totalCount || 0),
-    pageNo: Number(body.pageNo || 1),
-    numOfRows: Number(body.numOfRows || 0),
-    resultCode: body.resultCode || data?.resultCode || null,
-    resultMsg: body.resultMsg || data?.resultMsg || null,
+    totalCount: Number(root.totalCount || root.list_total_count || 0),
+    pageNo: Number(root.pageNo || 1),
+    numOfRows: Number(root.numOfRows || 0),
+    resultCode: root.resultCode || data?.resultCode || null,
+    resultMsg: root.resultMsg || data?.resultMsg || null,
   };
 };
 
@@ -178,39 +191,53 @@ const createSyncResult = ({
 
 // 법정동 전체 데이터를 조회해 region 테이블에 저장하는 메인 동기화 함수
 export const syncLegalRegions = async () => {
+  console.log("[legal region sync] 동기화 시작");
+  console.time("소요 시간");
   const { apiUrl, serviceKey } = legalRegionConfigValidator();
 
   const numOfRows = 1000;
-  let pageNo = 1;
-  let totalCount = 0;
-  let rawItems = [];
+  const firstPageData = await fetchLegalRegionPage({
+    pageNo: 1,
+    numOfRows,
+    apiUrl,
+    serviceKey,
+  });
 
-  while (true) {
-    const data = await fetchLegalRegionPage({
-      pageNo,
-      numOfRows,
-      apiUrl,
-      serviceKey,
-    });
+  const firstMeta = extractMetaFromResponse(firstPageData);
+  const firstItems = extractItemsFromResponse(firstPageData);
 
-    const meta = extractMetaFromResponse(data);
-    const items = extractItemsFromResponse(data);
+  const totalCount = firstMeta.totalCount;
+  let rawItems = [...firstItems];
 
-    if (pageNo === 1) {
-      totalCount = meta.totalCount;
+  const totalPages = totalCount > 0 ? Math.ceil(totalCount / numOfRows) : 1;
+
+  const chunkSize = 3;
+
+  if (totalPages >= 2) {
+    const pageNumbers = Array.from(
+      { length: totalPages - 1 },
+      (_, index) => index + 2,
+    );
+
+    for (let i = 0; i < pageNumbers.length; i += chunkSize) {
+      const pageChunk = pageNumbers.slice(i, i + chunkSize);
+
+      const pageResults = await Promise.all(
+        pageChunk.map((pageNo) =>
+          fetchLegalRegionPage({
+            pageNo,
+            numOfRows,
+            apiUrl,
+            serviceKey,
+          }),
+        ),
+      );
+
+      for (const data of pageResults) {
+        const items = extractItemsFromResponse(data);
+        rawItems.push(...items);
+      }
     }
-
-    rawItems = [...rawItems, ...items];
-
-    if (
-      items.length === 0 ||
-      (totalCount > 0 && rawItems.length >= totalCount) ||
-      items.length < numOfRows
-    ) {
-      break;
-    }
-
-    pageNo += 1;
   }
 
   const mappedRegions = rawItems.map(mapApiItemToRegion).filter(Boolean);
@@ -242,6 +269,7 @@ export const syncLegalRegions = async () => {
   console.log(
     `[legal region sync] 원본 ${result.totalCount}건 중 처리 ${result.processedCount}건, 성공 ${result.successCount}건, 실패 ${result.failedCount}건`,
   );
+  console.timeEnd("소요 시간");
 
   return result;
 };

--- a/services/region/regionService.js
+++ b/services/region/regionService.js
@@ -1,8 +1,4 @@
 import {
-  findSidoByName,
-  findChildRegionByNameAndParentCode,
-} from "../../model/region/regionModel.js";
-import {
   normalizeLocationText,
   normalizeSidoName,
   splitLocationTokens,
@@ -17,12 +13,9 @@ const buildResolveResult = ({ region = null, sourceText = "" }) => {
   };
 };
 
-const findMatchedChildRegion = async ({ candidates, parentCode }) => {
+const findMatchedChildRegion = ({ candidates, parentCode, sigunguMap }) => {
   for (const candidate of candidates) {
-    const matchedRegion = await findChildRegionByNameAndParentCode({
-      name: candidate,
-      parentCode,
-    });
+    const matchedRegion = sigunguMap.get(`${parentCode}:${candidate}`);
 
     if (matchedRegion) {
       return matchedRegion;
@@ -32,7 +25,8 @@ const findMatchedChildRegion = async ({ candidates, parentCode }) => {
   return null;
 };
 
-export const resolveRegionFromLocationText = async (locationText) => {
+export const resolveRegionFromLocationText = (locationText, regionCache) => {
+  const { sidoMap, sigunguMap } = regionCache;
   const sourceText = normalizeLocationText(locationText);
   const tokens = splitLocationTokens(locationText);
 
@@ -45,7 +39,7 @@ export const resolveRegionFromLocationText = async (locationText) => {
   const thirdToken = tokens[2] || null;
 
   // 1) 첫 토큰은 시/도
-  const sido = await findSidoByName(firstToken);
+  const sido = sidoMap.get(firstToken);
 
   if (!sido) {
     return buildResolveResult({ region: null, sourceText });
@@ -59,9 +53,10 @@ export const resolveRegionFromLocationText = async (locationText) => {
   // 3) 둘째 토큰은 시/도의 직속 자식
   const secondCandidates = buildChildRegionCandidates(secondToken);
 
-  const childRegion = await findMatchedChildRegion({
+  const childRegion = findMatchedChildRegion({
     candidates: secondCandidates,
     parentCode: sido.region_code,
+    sigunguMap,
   });
 
   if (!childRegion) {
@@ -76,13 +71,31 @@ export const resolveRegionFromLocationText = async (locationText) => {
   // 5) 셋째 토큰은 둘째 토큰의 직속 자식
   const thirdCandidates = buildChildRegionCandidates(thirdToken);
 
-  const grandChildRegion = await findMatchedChildRegion({
+  const grandChildRegion = findMatchedChildRegion({
     candidates: thirdCandidates,
     parentCode: childRegion.region_code,
+    sigunguMap,
   });
 
   return buildResolveResult({
     region: grandChildRegion || childRegion,
     sourceText,
   });
+};
+
+export const buildRegionCache = (regions) => {
+  const sidoMap = new Map();
+  const sigunguMap = new Map();
+
+  for (const region of regions) {
+    if (Number(region.level) === 1) {
+      sidoMap.set(region.name, region);
+    }
+
+    if (Number(region.level) === 2) {
+      sigunguMap.set(`${region.parent_code}:${region.name}`, region);
+    }
+  }
+
+  return { sidoMap, sigunguMap };
 };


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- region 전체 조회 후 메모리 캐시를 생성하도록 수정했습니다.
- 지역 해석 로직에서 반복 DB 조회를 제거하고 Map 기반 조회로 변경했습니다.
- 1365 지역코드 동기화 시 지역 캐시를 재사용하도록 수정했습니다.
- 법정동 동기화의 페이지 수집 로직을 개선해 fetch 병목을 줄이도록 수정했습니다.

### 테스트 결과
- 지역 매핑 로직이 캐시 기반으로 정상 동작하는지 확인
- 1365 지역코드 동기화 정상 동작 확인
- 법정동 동기화 정상 동작 확인
- 법정동 동기화 시간 측정 시 fetch 구간 병목 확인 및 개선 적용

### 관련 이슈
- Closes #37