### PR TITLE
[Refactor] 랭킹 조회 응답 구조 및 지역별 조회 기준 개선

### DIFF
--- a/model/rank/rankModel.js
+++ b/model/rank/rankModel.js
@@ -7,6 +7,7 @@ export const getNationalTop100 = async () => {
       u.id AS user_id,
       u.nickname,
       u.region_code,
+      r.name AS region_name,
       COALESCE(SUM(vp.approved_volunteer_hour), 0) AS total_hours,
       RANK() OVER (
         ORDER BY COALESCE(SUM(vp.approved_volunteer_hour), 0) DESC
@@ -15,8 +16,10 @@ export const getNationalTop100 = async () => {
     LEFT JOIN volunteer_participation vp
       ON vp.user_id = u.id
       AND vp.participation_status = 'APPROVED'
+    LEFT JOIN region r
+      ON r.region_code = u.region_code
     WHERE u.role = 'USER'
-    GROUP BY u.id, u.nickname, u.region_code
+    GROUP BY u.id, u.nickname, u.region_code, r.name
     ORDER BY total_hours DESC, user_id ASC
     LIMIT 100
   `;
@@ -32,6 +35,7 @@ export const getSidoTop100 = async (sidoCode) => {
       u.id AS user_id,
       u.nickname,
       u.region_code,
+      r.name AS region_name,
       COALESCE(SUM(vp.approved_volunteer_hour), 0) AS total_hours,
       RANK() OVER (
         ORDER BY COALESCE(SUM(vp.approved_volunteer_hour), 0) DESC
@@ -44,7 +48,7 @@ export const getSidoTop100 = async (sidoCode) => {
       ON r.region_code = u.region_code
     WHERE u.role = 'USER'
       AND r.parent_code = ?
-    GROUP BY u.id, u.nickname, u.region_code
+    GROUP BY u.id, u.nickname, u.region_code, r.name
     ORDER BY total_hours DESC, user_id ASC
     LIMIT 100
   `;
@@ -60,6 +64,7 @@ export const getSigunguTop100 = async (sigunguCode) => {
       u.id AS user_id,
       u.nickname,
       u.region_code,
+      r.name AS region_name,
       COALESCE(SUM(vp.approved_volunteer_hour), 0) AS total_hours,
       RANK() OVER (
         ORDER BY COALESCE(SUM(vp.approved_volunteer_hour), 0) DESC
@@ -68,9 +73,11 @@ export const getSigunguTop100 = async (sigunguCode) => {
     LEFT JOIN volunteer_participation vp
       ON vp.user_id = u.id
       AND vp.participation_status = 'APPROVED'
+    LEFT JOIN region r
+      ON r.region_code = u.region_code
     WHERE u.role = 'USER'
       AND u.region_code = ?
-    GROUP BY u.id, u.nickname, u.region_code
+    GROUP BY u.id, u.nickname, u.region_code, r.name
     ORDER BY total_hours DESC, user_id ASC
     LIMIT 100
   `;
@@ -87,12 +94,14 @@ export const getMyNationalRank = async (userId) => {
       total_hours,
       user_id,
       nickname,
-      region_code
+      region_code,
+      region_name
     FROM (
       SELECT
         u.id AS user_id,
         u.nickname,
         u.region_code,
+        r.name AS region_name,
         COALESCE(SUM(vp.approved_volunteer_hour), 0) AS total_hours,
         RANK() OVER (
           ORDER BY COALESCE(SUM(vp.approved_volunteer_hour), 0) DESC
@@ -101,8 +110,10 @@ export const getMyNationalRank = async (userId) => {
       LEFT JOIN volunteer_participation vp
         ON vp.user_id = u.id
         AND vp.participation_status = 'APPROVED'
+      LEFT JOIN region r
+        ON r.region_code = u.region_code
       WHERE u.role = 'USER'
-      GROUP BY u.id, u.nickname, u.region_code
+      GROUP BY u.id, u.nickname, u.region_code, r.name
     ) ranked
     WHERE user_id = ?
   `;
@@ -119,12 +130,14 @@ export const getMySidoRank = async (userId, sidoCode) => {
       total_hours,
       user_id,
       nickname,
-      region_code
+      region_code,
+      region_name
     FROM (
       SELECT
         u.id AS user_id,
         u.nickname,
         u.region_code,
+        r.name AS region_name,
         COALESCE(SUM(vp.approved_volunteer_hour), 0) AS total_hours,
         RANK() OVER (
           ORDER BY COALESCE(SUM(vp.approved_volunteer_hour), 0) DESC
@@ -137,7 +150,7 @@ export const getMySidoRank = async (userId, sidoCode) => {
         ON r.region_code = u.region_code
       WHERE u.role = 'USER'
         AND r.parent_code = ?
-      GROUP BY u.id, u.nickname, u.region_code
+      GROUP BY u.id, u.nickname, u.region_code, r.name
     ) ranked
     WHERE user_id = ?
   `;
@@ -154,12 +167,14 @@ export const getMySigunguRank = async (userId, sigunguCode) => {
       total_hours,
       user_id,
       nickname,
-      region_code
+      region_code,
+      region_name
     FROM (
       SELECT
         u.id AS user_id,
         u.nickname,
         u.region_code,
+        r.name AS region_name,
         COALESCE(SUM(vp.approved_volunteer_hour), 0) AS total_hours,
         RANK() OVER (
           ORDER BY COALESCE(SUM(vp.approved_volunteer_hour), 0) DESC
@@ -168,9 +183,11 @@ export const getMySigunguRank = async (userId, sigunguCode) => {
       LEFT JOIN volunteer_participation vp
         ON vp.user_id = u.id
         AND vp.participation_status = 'APPROVED'
+      LEFT JOIN region r
+        ON r.region_code = u.region_code
       WHERE u.role = 'USER'
         AND u.region_code = ?
-      GROUP BY u.id, u.nickname, u.region_code
+      GROUP BY u.id, u.nickname, u.region_code, r.name
     ) ranked
     WHERE user_id = ?
   `;

--- a/model/rank/rankModel.js
+++ b/model/rank/rankModel.js
@@ -17,7 +17,7 @@ export const getNationalTop100 = async () => {
       AND vp.participation_status = 'APPROVED'
     WHERE u.role = 'USER'
     GROUP BY u.id, u.nickname, u.region_code
-    ORDER BY rank_position ASC
+    ORDER BY total_hours DESC, user_id ASC
     LIMIT 100
   `;
 
@@ -45,11 +45,11 @@ export const getRegionalTop100 = async (regionCode) => {
       ON r.region_code = u.region_code
     WHERE u.role = 'USER'
       AND (
-        u.region_code = ?          -- 시군구 코드로 직접 매칭
-        OR r.parent_code = ?       -- 시도 코드로 하위 시군구 전체 포함
+        u.region_code = ?       -- 시군구 코드로 직접 매칭
+        OR r.parent_code = ?    -- 시도 코드로 하위 시군구 전체 포함
       )
     GROUP BY u.id, u.nickname, u.region_code
-    ORDER BY rank_position ASC
+    ORDER BY total_hours DESC, user_id ASC
     LIMIT 100
   `;
 
@@ -74,13 +74,14 @@ export const getMyNationalRank = async (userId) => {
       LEFT JOIN volunteer_participation vp
         ON vp.user_id = u.id
         AND vp.participation_status = 'APPROVED'
+      WHERE u.role = 'USER'
       GROUP BY u.id, u.nickname, u.region_code
     ) ranked
     WHERE user_id = ?
   `;
 
   const [rows] = await conn.execute(sql, [userId]);
-  
+
   return rows[0] ?? null;
 };
 
@@ -105,8 +106,8 @@ export const getMyRegionalRank = async (userId, regionCode) => {
         ON r.region_code = u.region_code
       WHERE u.role = 'USER'
         AND (
-          u.region_code = ?        -- 시군구 직접 매칭
-          OR r.parent_code = ?     -- 시도 하위 전체 포함
+          u.region_code = ?           -- 시군구 직접 매칭
+          OR r.parent_code = ?        -- 시도 하위 전체 포함
         )
       GROUP BY u.id, u.nickname, u.region_code
     ) ranked

--- a/model/rank/rankModel.js
+++ b/model/rank/rankModel.js
@@ -22,12 +22,11 @@ export const getNationalTop100 = async () => {
   `;
 
   const [rows] = await conn.execute(sql);
-
   return rows;
 };
 
-// 지역별 TOP 100 조회
-export const getRegionalTop100 = async (regionCode) => {
+// 시도 기준 TOP 100 조회
+export const getSidoTop100 = async (sidoCode) => {
   const sql = `
     SELECT
       u.id AS user_id,
@@ -44,23 +43,51 @@ export const getRegionalTop100 = async (regionCode) => {
     JOIN region r
       ON r.region_code = u.region_code
     WHERE u.role = 'USER'
-      AND (
-        u.region_code = ?       -- 시군구 코드로 직접 매칭
-        OR r.parent_code = ?    -- 시도 코드로 하위 시군구 전체 포함
-      )
+      AND r.parent_code = ?
     GROUP BY u.id, u.nickname, u.region_code
     ORDER BY total_hours DESC, user_id ASC
     LIMIT 100
   `;
 
-  const [rows] = await conn.execute(sql, [regionCode, regionCode]);
+  const [rows] = await conn.execute(sql, [sidoCode]);
+  return rows;
+};
+
+// 시군구 기준 TOP 100 조회
+export const getSigunguTop100 = async (sigunguCode) => {
+  const sql = `
+    SELECT
+      u.id AS user_id,
+      u.nickname,
+      u.region_code,
+      COALESCE(SUM(vp.approved_volunteer_hour), 0) AS total_hours,
+      RANK() OVER (
+        ORDER BY COALESCE(SUM(vp.approved_volunteer_hour), 0) DESC
+      ) AS rank_position
+    FROM users u
+    LEFT JOIN volunteer_participation vp
+      ON vp.user_id = u.id
+      AND vp.participation_status = 'APPROVED'
+    WHERE u.role = 'USER'
+      AND u.region_code = ?
+    GROUP BY u.id, u.nickname, u.region_code
+    ORDER BY total_hours DESC, user_id ASC
+    LIMIT 100
+  `;
+
+  const [rows] = await conn.execute(sql, [sigunguCode]);
   return rows;
 };
 
 // 전국 기준 내 순위 조회
 export const getMyNationalRank = async (userId) => {
   const sql = `
-    SELECT rank_position, total_hours, user_id, nickname, region_code
+    SELECT
+      rank_position,
+      total_hours,
+      user_id,
+      nickname,
+      region_code
     FROM (
       SELECT
         u.id AS user_id,
@@ -81,14 +108,18 @@ export const getMyNationalRank = async (userId) => {
   `;
 
   const [rows] = await conn.execute(sql, [userId]);
-
   return rows[0] ?? null;
 };
 
-// 지역 기준 내 순위 조회
-export const getMyRegionalRank = async (userId, regionCode) => {
+// 시도 기준 내 순위 조회
+export const getMySidoRank = async (userId, sidoCode) => {
   const sql = `
-    SELECT rank_position, total_hours, user_id, nickname, region_code
+    SELECT
+      rank_position,
+      total_hours,
+      user_id,
+      nickname,
+      region_code
     FROM (
       SELECT
         u.id AS user_id,
@@ -105,15 +136,45 @@ export const getMyRegionalRank = async (userId, regionCode) => {
       JOIN region r
         ON r.region_code = u.region_code
       WHERE u.role = 'USER'
-        AND (
-          u.region_code = ?           -- 시군구 직접 매칭
-          OR r.parent_code = ?        -- 시도 하위 전체 포함
-        )
+        AND r.parent_code = ?
       GROUP BY u.id, u.nickname, u.region_code
     ) ranked
     WHERE user_id = ?
   `;
 
-  const [rows] = await conn.execute(sql, [regionCode, regionCode, userId]);
+  const [rows] = await conn.execute(sql, [sidoCode, userId]);
+  return rows[0] ?? null;
+};
+
+// 시군구 기준 내 순위 조회
+export const getMySigunguRank = async (userId, sigunguCode) => {
+  const sql = `
+    SELECT
+      rank_position,
+      total_hours,
+      user_id,
+      nickname,
+      region_code
+    FROM (
+      SELECT
+        u.id AS user_id,
+        u.nickname,
+        u.region_code,
+        COALESCE(SUM(vp.approved_volunteer_hour), 0) AS total_hours,
+        RANK() OVER (
+          ORDER BY COALESCE(SUM(vp.approved_volunteer_hour), 0) DESC
+        ) AS rank_position
+      FROM users u
+      LEFT JOIN volunteer_participation vp
+        ON vp.user_id = u.id
+        AND vp.participation_status = 'APPROVED'
+      WHERE u.role = 'USER'
+        AND u.region_code = ?
+      GROUP BY u.id, u.nickname, u.region_code
+    ) ranked
+    WHERE user_id = ?
+  `;
+
+  const [rows] = await conn.execute(sql, [sigunguCode, userId]);
   return rows[0] ?? null;
 };

--- a/model/region/regionModel.js
+++ b/model/region/regionModel.js
@@ -12,7 +12,7 @@ export const findAllSidos = async () => {
     ORDER BY region_code ASC
   `;
 
-  const [rows] = await pool.query(sql);
+  const [rows] = await pool.execute(sql);
   return rows;
 };
 
@@ -28,7 +28,7 @@ export const findChildRegionsByParentCode = async (parentCode) => {
     ORDER BY region_code ASC
   `;
 
-  const [rows] = await pool.query(sql, [parentCode]);
+  const [rows] = await pool.execute(sql, [parentCode]);
   return rows;
 };
 
@@ -44,7 +44,7 @@ export const findRegionByNameAndLevel = async ({ name, level }) => {
     LIMIT 1
   `;
 
-  const [rows] = await pool.query(sql, [name, level]);
+  const [rows] = await pool.execute(sql, [name, level]);
   return rows[0] || null;
 };
 
@@ -64,7 +64,7 @@ export const findChildRegionByNameAndParentCode = async ({
     LIMIT 1
   `;
 
-  const [rows] = await pool.query(sql, [name, parentCode]);
+  const [rows] = await pool.execute(sql, [name, parentCode]);
   return rows[0] || null;
 };
 
@@ -87,7 +87,7 @@ export const upsertRegion = async ({ regionCode, name, level, parentCode }) => {
       parent_code = VALUES(parent_code)
   `;
 
-  await pool.query(sql, [regionCode, name, level, parentCode]);
+  await pool.execute(sql, [regionCode, name, level, parentCode]);
 };
 
 export const findAllRegions = async () => {
@@ -95,6 +95,22 @@ export const findAllRegions = async () => {
     SELECT region_code, name, level, parent_code
     FROM region
   `;
-  const [rows] = await pool.query(sql);
+  const [rows] = await pool.execute(sql);
   return rows;
+};
+
+export const findRegionByCode = async (regionCode) => {
+  const sql = `
+    SELECT
+      region_code,
+      name,
+      level,
+      parent_code
+    FROM region
+    WHERE region_code = ?
+    LIMIT 1
+  `;
+
+  const [rows] = await pool.execute(sql, [regionCode]);
+  return rows[0] ?? null;
 };

--- a/services/rank/rankService.js
+++ b/services/rank/rankService.js
@@ -1,58 +1,88 @@
+import { findRegionByCode } from "../../model/region/regionModel.js";
 import {
   getNationalTop100,
-  getRegionalTop100,
+  getSidoTop100,
+  getSigunguTop100,
   getMyNationalRank,
-  getMyRegionalRank,
+  getMySidoRank,
+  getMySigunguRank,
 } from "../../model/rank/rankModel.js";
+
+const addIsMeFlag = (rows, userId) => {
+  return rows.map((row) => ({
+    ...row,
+    is_me: userId ? row.user_id === userId : false,
+  }));
+};
 
 // 전국 랭킹 조회
 export const getNationalRanking = async (userId) => {
   const top100 = await getNationalTop100();
+  const top100WithFlag = addIsMeFlag(top100, userId);
 
-  const top100WithFlag = top100.map((row) => ({
-    ...row,
-    is_me: userId ? row.user_id === userId : false,
-  }));
-
-  // 비로그인
   if (!userId) {
     return { top100: top100WithFlag, myRank: null };
   }
 
   const isInTop100 = top100WithFlag.some((row) => row.user_id === userId);
 
-  // TOP100 안에 있으면
   if (isInTop100) {
     return { top100: top100WithFlag, myRank: null };
   }
 
-  // TOP100 밖이면 내 순위 따로 조회
   const myRank = await getMyNationalRank(userId);
-  return { top100: top100WithFlag, myRank };
+
+  return {
+    top100: top100WithFlag,
+    myRank,
+  };
 };
 
-// 지역별 랭킹 조회
+// 지역 랭킹 조회
 export const getRegionalRanking = async (regionCode, userId) => {
-  const top100 = await getRegionalTop100(regionCode);
+  const region = await findRegionByCode(regionCode);
 
-  const top100WithFlag = top100.map((row) => ({
-    ...row,
-    is_me: userId ? row.user_id === userId : false,
-  }));
+  if (!region) {
+    const error = new Error("존재하지 않는 지역입니다.");
+    error.status = 404;
+    throw error;
+  }
 
-  // 비로그인
+  let top100 = [];
+  let myRank = null;
+
+  if (region.level === 1) {
+    top100 = await getSidoTop100(regionCode);
+
+    if (userId) {
+      myRank = await getMySidoRank(userId, regionCode);
+    }
+  } else if (region.level === 2) {
+    top100 = await getSigunguTop100(regionCode);
+
+    if (userId) {
+      myRank = await getMySigunguRank(userId, regionCode);
+    }
+  } else {
+    const error = new Error("지원하지 않는 지역 레벨입니다.");
+    error.status = 400;
+    throw error;
+  }
+
+  const top100WithFlag = addIsMeFlag(top100, userId);
+
   if (!userId) {
     return { top100: top100WithFlag, myRank: null };
   }
 
   const isInTop100 = top100WithFlag.some((row) => row.user_id === userId);
 
-  // TOP100 안에 있으면
   if (isInTop100) {
     return { top100: top100WithFlag, myRank: null };
   }
 
-  // TOP100 밖이면 내 순위 따로 조회
-  const myRank = await getMyRegionalRank(userId, regionCode);
-  return { top100: top100WithFlag, myRank };
+  return {
+    top100: top100WithFlag,
+    myRank,
+  };
 };

--- a/services/rank/rankService.js
+++ b/services/rank/rankService.js
@@ -11,8 +11,28 @@ import {
 const addIsMeFlag = (rows, userId) => {
   return rows.map((row) => ({
     ...row,
+    total_hours: Number(row.total_hours),
     is_me: userId ? row.user_id === userId : false,
   }));
+};
+
+const normalizeMyRank = (row, userId) => {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    ...row,
+    total_hours: Number(row.total_hours),
+    is_me: userId ? row.user_id === userId : false,
+  };
+};
+
+const buildTargetRegion = (region) => {
+  return {
+    regionCode: region.region_code,
+    regionName: region.name,
+  };
 };
 
 // 전국 랭킹 조회
@@ -21,20 +41,29 @@ export const getNationalRanking = async (userId) => {
   const top100WithFlag = addIsMeFlag(top100, userId);
 
   if (!userId) {
-    return { top100: top100WithFlag, myRank: null };
+    return {
+      targetRegion: null,
+      top100: top100WithFlag,
+      myRank: null,
+    };
   }
 
   const isInTop100 = top100WithFlag.some((row) => row.user_id === userId);
 
   if (isInTop100) {
-    return { top100: top100WithFlag, myRank: null };
+    return {
+      targetRegion: null,
+      top100: top100WithFlag,
+      myRank: null,
+    };
   }
 
   const myRank = await getMyNationalRank(userId);
 
   return {
+    targetRegion: null,
     top100: top100WithFlag,
-    myRank,
+    myRank: normalizeMyRank(myRank, userId),
   };
 };
 
@@ -47,6 +76,8 @@ export const getRegionalRanking = async (regionCode, userId) => {
     error.status = 404;
     throw error;
   }
+
+  const targetRegion = buildTargetRegion(region);
 
   let top100 = [];
   let myRank = null;
@@ -72,17 +103,26 @@ export const getRegionalRanking = async (regionCode, userId) => {
   const top100WithFlag = addIsMeFlag(top100, userId);
 
   if (!userId) {
-    return { top100: top100WithFlag, myRank: null };
+    return {
+      targetRegion,
+      top100: top100WithFlag,
+      myRank: null,
+    };
   }
 
   const isInTop100 = top100WithFlag.some((row) => row.user_id === userId);
 
   if (isInTop100) {
-    return { top100: top100WithFlag, myRank: null };
+    return {
+      targetRegion,
+      top100: top100WithFlag,
+      myRank: null,
+    };
   }
 
   return {
+    targetRegion,
     top100: top100WithFlag,
-    myRank,
+    myRank: normalizeMyRank(myRank, userId),
   };
 };

--- a/services/rank/rankService.js
+++ b/services/rank/rankService.js
@@ -1,32 +1,32 @@
-import { 
-    getNationalTop100,
-    getRegionalTop100,
-    getMyNationalRank, 
-    getMyRegionalRank 
-} from '../../model/rank/rankModel.js';
+import {
+  getNationalTop100,
+  getRegionalTop100,
+  getMyNationalRank,
+  getMyRegionalRank,
+} from "../../model/rank/rankModel.js";
 
 // 전국 랭킹 조회
 export const getNationalRanking = async (userId) => {
   const top100 = await getNationalTop100();
 
-  // 비로그인
-  if (!userId) {
-    return { top100, myRank: null };
-  }
-
-  const isInTop100 = top100.some((row) => row.user_id === userId);
-
   const top100WithFlag = top100.map((row) => ({
     ...row,
-    is_me: row.user_id === userId,
+    is_me: userId ? row.user_id === userId : false,
   }));
+
+  // 비로그인
+  if (!userId) {
+    return { top100: top100WithFlag, myRank: null };
+  }
+
+  const isInTop100 = top100WithFlag.some((row) => row.user_id === userId);
 
   // TOP100 안에 있으면
   if (isInTop100) {
     return { top100: top100WithFlag, myRank: null };
   }
 
-  // 밖이면 내 순위 따로 조회
+  // TOP100 밖이면 내 순위 따로 조회
   const myRank = await getMyNationalRank(userId);
   return { top100: top100WithFlag, myRank };
 };
@@ -35,24 +35,24 @@ export const getNationalRanking = async (userId) => {
 export const getRegionalRanking = async (regionCode, userId) => {
   const top100 = await getRegionalTop100(regionCode);
 
-  // 비로그인
-  if (!userId) {
-    return { top100, myRank: null };
-  }
-
-  const isInTop100 = top100.some((row) => row.user_id === userId);
-
   const top100WithFlag = top100.map((row) => ({
     ...row,
-    is_me: row.user_id === userId,
+    is_me: userId ? row.user_id === userId : false,
   }));
+
+  // 비로그인
+  if (!userId) {
+    return { top100: top100WithFlag, myRank: null };
+  }
+
+  const isInTop100 = top100WithFlag.some((row) => row.user_id === userId);
 
   // TOP100 안에 있으면
   if (isInTop100) {
     return { top100: top100WithFlag, myRank: null };
   }
 
-  // 밖이면 내 순위 따로 조회
+  // TOP100 밖이면 내 순위 따로 조회
   const myRank = await getMyRegionalRank(userId, regionCode);
   return { top100: top100WithFlag, myRank };
 };


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 랭킹 조회 응답에 region_name 필드를 포함하도록 수정했습니다.
- 지역 랭킹 조회 시 시도와 시군구 기준을 분리해 조회 범위를 명확하게 적용하도록 수정했습니다.
- 로그인 여부와 관계없이 is_me 필드를 일관되게 반환하도록 정리했습니다.
- total_hours 값을 숫자형으로 정규화하도록 수정했습니다.
- 동점자 출력 순서가 안정적으로 유지되도록 보조 정렬 기준을 추가했습니다.

### 테스트 결과
- 전국 랭킹 조회 시 지역명이 함께 반환되는 것 확인
- 시도 코드 조회 시 하위 시군구 전체가 포함되어 조회되는 것 확인
- 시군구 코드 조회 시 해당 지역만 조회되는 것 확인
- 로그인/비로그인 상태 모두 is_me 필드가 일관되게 반환되는 것 확인
- 동점자 데이터에서 정렬 순서가 일관되게 유지되는 것 확인

### 관련 이슈
- Closes #42